### PR TITLE
Added ability to test from fork

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
 
+# INSTRUCTIONS FOR TESTING FROM FORKED REPOS
+# Prerequisites: 
+# 1. Fork the following repos to your github user repo:
+#    a) Gutenberg-Mobile: https://github.com/wordpress-mobile/gutenberg-mobile
+#    * .gitmodules on CURRENT_BRANCH should reference your gutenberg fork, replace 'WordPress' with GITHUB_USERNAME 
+#    * (https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/.gitmodules)
+#    b) Gutenberg: https://github.com/WordPress/gutenberg
+#    c) WordPress-Android: https://github.com/wordpress-mobile/WordPress-Android
+#    d) WordPress-iOS: https://github.com/wordpress-mobile/WordPress-iOS
+# 2. Insure that each of your forked repos contains the PR labels specified below:
+GUTENBERG_MOBILE_PR_LABEL="release-process"
+GUTENBERG_PR_LABEL="Mobile App Android/iOS"
+WPANDROID_PR_LABEL="gutenberg-mobile"
+WPIOS_PR_LABEL="Gutenberg integration"
+# 3. Ensure that each of your repos contains the target branch listed below:
+GUTENBERG_MOBILE_TARGET_BRANCH="trunk"
+GUTENBERG_TARGET_BRANCH="master"
+WPANDROID_TARGET_BRANCH="develop"
+WPIOS_TARGET_BRANCH="develop"
+# 4. Update the repo names below to the user repo name for your fork
+GUTENBERG_REPO="WordPress"
+MOBILE_REPO="wordpress-mobile"
+#GUTENBERG_REPO="YOUR_GITHUB_USERNAME"
+#MOBILE_REPO="YOUR_GITHUB_USERNAME"
+
 # Before creating the release, this script performs the following checks:
 # - AztecAndroid and WordPress-Aztec-iOS are set to release versions
 # - Release is being created off of either develop, main, or release/*
@@ -153,11 +178,11 @@ PR_BODY=${PR_TEMPLATE//v1.XX.Y/$VERSION_NUMBER}
 
 # Insure PR is created on proper remote
 # see https://github.com/cli/cli/issues/800
-BASE_REMOTE=$(get_remote_name 'wordpress-mobile/gutenberg-mobile')
+BASE_REMOTE=$(get_remote_name "$MOBILE_REPO/gutenberg-mobile")
 execute "git" "push" "-u" "$BASE_REMOTE" "HEAD"
 
 # Create Draft GB-Mobile Release PR in GitHub
-GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" "--title" "Release $VERSION_NUMBER" "--body" "$PR_BODY" "--base" "trunk" "--label" "release-process" "--draft")
+GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" "--title" "Release $VERSION_NUMBER" "--body" "$PR_BODY" "--repo" "$MOBILE_REPO/gutenberg-mobile" "--base" "$GUTENBERG_MOBILE_TARGET_BRANCH" "--label" "$GUTENBERG_MOBILE_PR_LABEL" "--draft")
 
 #####
 # Gutenberg PR
@@ -181,11 +206,11 @@ $CHECKLIST_FROM_GUTENBERG_PR_TEMPLATE"
 
 # Insure PR is created on proper remote
 # see https://github.com/cli/cli/issues/800
-GB_BASE_REMOTE=$(get_remote_name 'WordPress/gutenberg')
+GB_BASE_REMOTE=$(get_remote_name "$GUTENBERG_REPO/gutenberg")
 execute "git" "push" "-u" "$GB_BASE_REMOTE" "HEAD"
 
 # Create Draft Gutenberg Release PR in GitHub
-GUTENBERG_PR_URL=$(execute "gh" "pr" "create" "--title" "Mobile Release v$VERSION_NUMBER" "--body" "$GUTENBERG_PR_BODY" "--base" "master" "--label" "Mobile App Android/iOS" "--draft")
+GUTENBERG_PR_URL=$(execute "gh" "pr" "create" "--title" "Mobile Release v$VERSION_NUMBER" "--body" "$GUTENBERG_PR_BODY" "--repo" "$GUTENBERG_REPO/gutenberg" "--base" "$GUTENBERG_TARGET_BRANCH" "--label" "$GUTENBERG_PR_LABEL" "--draft")
 cd ..
 
 echo "PRs Created"
@@ -204,7 +229,7 @@ GB_MOBILE_PR_REF=$(git rev-parse HEAD)
 
 TEMP_WP_ANDROID_DIRECTORY=$(mktemp -d)
 ohai "Clone WordPress-Android into '$TEMP_WP_ANDROID_DIRECTORY'"
-execute "git" "clone" "--depth=1" "git@github.com:wordpress-mobile/WordPress-Android.git" "$TEMP_WP_ANDROID_DIRECTORY"
+execute "git" "clone" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-Android.git" "$TEMP_WP_ANDROID_DIRECTORY"
 
 cd "$TEMP_WP_ANDROID_DIRECTORY"
 
@@ -215,7 +240,7 @@ execute "git" "switch" "-c" "gutenberg/after_$VERSION_NUMBER"
 
 # Insure PR is created on proper remote
 # see https://github.com/cli/cli/issues/800
-WP_ANDROID_BASE_REMOTE=$(get_remote_name 'wordpress-mobile/WordPress-Android')
+WP_ANDROID_BASE_REMOTE=$(get_remote_name "$MOBILE_REPO/WordPress-Android")
 execute "git" "push" "-u" "$WP_ANDROID_BASE_REMOTE" "HEAD"
 
 ohai "Create release branch in WordPress-Android"
@@ -255,7 +280,7 @@ Release Submission Checklist
 
 # Create Draft WPAndroid Release PR in GitHub
 ohai "Create Draft WPAndroid Release PR in GitHub"
-WP_ANDROID_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_ANDROID_PR_BODY" "--base" "develop" "--label" "gutenberg-mobile" "--draft")
+WP_ANDROID_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_ANDROID_PR_BODY" --repo "$MOBILE_REPO/WordPress-Android" "--base" "$WPANDROID_TARGET_BRANCH" "--label" "$WPANDROID_PR_LABEL" "--draft")
 
 ohai "WPAndroid PR Created: $WP_ANDROID_PR_URL"
 echo ""
@@ -267,7 +292,7 @@ echo ""
 
 TEMP_WP_IOS_DIRECTORY=$(mktemp -d)
 ohai "Clone WordPress-iOS into '$TEMP_WP_IOS_DIRECTORY'"
-execute "git" "clone" "--depth=1" "git@github.com:wordpress-mobile/WordPress-iOS.git" "$TEMP_WP_IOS_DIRECTORY"
+execute "git" "clone" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-iOS.git" "$TEMP_WP_IOS_DIRECTORY"
 
 cd "$TEMP_WP_IOS_DIRECTORY"
 
@@ -276,7 +301,7 @@ execute "git" "switch" "-c" "gutenberg/after_$VERSION_NUMBER"
 
 # Insure PR is created on proper remote
 # see https://github.com/cli/cli/issues/800
-WP_IOS_BASE_REMOTE=$(get_remote_name 'wordpress-mobile/WordPress-iOS')
+WP_IOS_BASE_REMOTE=$(get_remote_name "$MOBILE_REPO/WordPress-iOS")
 execute "git" "push" "-u" "$WP_IOS_BASE_REMOTE" "HEAD"
 
 ohai "Create release branch in WordPress-iOS"
@@ -304,7 +329,7 @@ Release Submission Checklist
 
 # Create Draft WPiOS Release PR in GitHub
 ohai "Create Draft WPiOS Release PR in GitHub"
-WP_IOS_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_IOS_PR_BODY" "--base" "develop" "--label" "Gutenberg integration" "--draft")
+WP_IOS_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_IOS_PR_BODY" --repo "$MOBILE_REPO/WordPress-iOS" "--base" "$WPIOS_TARGET_BRANCH" "--label" "$WPIOS_PR_LABEL" "--draft")
 
 ohai "WPiOS PR Created: $WP_IOS_PR_URL"
 echo ""


### PR DESCRIPTION
## Description
Adds instructions for testing gutenberg-mobile release scripts and PR creation on a fork

## How it was Tested
I tested following the instructions at the top of the `release_automation.sh` and was able to create all release PR's on my cameronvoell fork except for the WPiOS PR. 

The WPiOS PR still fails because the `rake dependencies` tries to get the gutenberg-mobile commit from wordpress-mobile repo.