### PR TITLE
Release script improvements

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -156,13 +156,19 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 fi
 cd ..
 
+# Commit updates to gutenberg submodule
+ohai "Commit updates to gutenberg submodule"
+execute "git" "add" "gutenberg"
+execute "git" "commit" "-m" "Release script: Update gutenberg ref"
+
 # Update the bundles
 ohai "Update the bundles"
 npm run bundle || abort "Error: 'npm bundle' failed.\nIf there is an error stating something like \"Command 'bundle' unrecognized.\" above, perhaps try running 'rm -rf node_modules gutenberg/node_modules && npm ci'."
 
-# Commit bundle changes along with any update to the gutenberg submodule (if necessary)
-ohai "Commit bundle changes along with any update to the gutenberg submodule (if necessary)"
-execute "git" "commit" "-a" "-m" "Release script: Update bundle for: $VERSION_NUMBER"
+# Commit bundle changes
+ohai "Commit bundle changes"
+execute "git" "add" "bundle/"
+execute "git" "commit" "-m" "Release script: Update bundle for: $VERSION_NUMBER"
 
 
 #####

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -223,6 +223,14 @@ ohai "Proceeding to create main apps PRs..."
 
 GB_MOBILE_PR_REF=$(git rev-parse HEAD)
 
+WP_APPS_PR_BODY="## Description
+This PR incorporates the $VERSION_NUMBER release of gutenberg-mobile.  
+For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: $GB_MOBILE_PR_URL
+
+Release Submission Checklist
+
+- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
+
 #####
 # WPAndroid PR
 #####
@@ -270,17 +278,9 @@ fi
 ohai "Push integration branch"
 execute "git" "push" "-u" "$WP_ANDROID_BASE_REMOTE" "HEAD"
 
-WP_ANDROID_PR_BODY="## Description
-This PR incorporates the $VERSION_NUMBER release of gutenberg-mobile.  
-For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: $GB_MOBILE_PR_URL
-
-Release Submission Checklist
-
-- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
-
 # Create Draft WPAndroid Release PR in GitHub
 ohai "Create Draft WPAndroid Release PR in GitHub"
-WP_ANDROID_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_ANDROID_PR_BODY" --repo "$MOBILE_REPO/WordPress-Android" "--base" "$WPANDROID_TARGET_BRANCH" "--label" "$WPANDROID_PR_LABEL" "--draft")
+WP_ANDROID_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_APPS_PR_BODY" --repo "$MOBILE_REPO/WordPress-Android" "--base" "$WPANDROID_TARGET_BRANCH" "--label" "$WPANDROID_PR_LABEL" "--draft")
 
 ohai "WPAndroid PR Created: $WP_ANDROID_PR_URL"
 echo ""
@@ -319,17 +319,9 @@ execute "git" "commit" "-m" "Release script: Update gutenberg-mobile ref"
 ohai "Push integration branch"
 execute "git" "push" "-u" "$WP_IOS_BASE_REMOTE" "HEAD"
 
-WP_IOS_PR_BODY="## Description
-This PR incorporates the $VERSION_NUMBER release of gutenberg-mobile.  
-For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: $GB_MOBILE_PR_URL
-
-Release Submission Checklist
-
-- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
-
 # Create Draft WPiOS Release PR in GitHub
 ohai "Create Draft WPiOS Release PR in GitHub"
-WP_IOS_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_IOS_PR_BODY" --repo "$MOBILE_REPO/WordPress-iOS" "--base" "$WPIOS_TARGET_BRANCH" "--label" "$WPIOS_PR_LABEL" "--draft")
+WP_IOS_PR_URL=$(execute "gh" "pr" "create" "--title" "Integrate gutenberg-mobile release $VERSION_NUMBER" "--body" "$WP_APPS_PR_BODY" --repo "$MOBILE_REPO/WordPress-iOS" "--base" "$WPIOS_TARGET_BRANCH" "--label" "$WPIOS_PR_LABEL" "--draft")
 
 ohai "WPiOS PR Created: $WP_IOS_PR_URL"
 echo ""

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -146,6 +146,15 @@ else
 fi
 cd ..
 
+# Ask if a cherry-pick is needed before bundling (for example if this is a hotfix release)
+cd gutenberg
+read -p "Do you want to cherry-pick a commit from gutenberg? (y/n) " -n 1
+echo ""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    read -p "Enter the commit hash to cherry-pick: " GUTENBERG_COMMIT_HASH_TO_CHERRY_PICK
+    execute "git" "cherry-pick" "$GUTENBERG_COMMIT_HASH_TO_CHERRY_PICK"
+fi
+cd ..
 
 # Update the bundles
 ohai "Update the bundles"

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -198,7 +198,7 @@ GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" \
 "--title" "Release $VERSION_NUMBER" \
 "--body" "$PR_BODY" \
 "--repo" "$MOBILE_REPO/gutenberg-mobile" \
-"--head" "$MOBILE_REPO:$RELEASE_BRANCH"
+"--head" "$MOBILE_REPO:$RELEASE_BRANCH" \
 "--base" "$GUTENBERG_MOBILE_TARGET_BRANCH" \
 "--label" "$GUTENBERG_MOBILE_PR_LABEL" \
 "--draft")

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -243,13 +243,19 @@ Release Submission Checklist
 
 WP_APPS_INTEGRATION_BRANCH="gutenberg/integrate_release_$VERSION_NUMBER"
 
+
 #####
 # WPAndroid PR
 #####
+read -p "Do you want to target $WPANDROID_TARGET_BRANCH branch for WPAndroid PR? (y/n) " -n 1
+echo ""
+if [[ $REPLY =~ ^[Nn]$ ]]; then
+    read -p "Enter the branch name you want to target. Make sure a branch with this name already exists in WPAndroid repository: " WPANDROID_TARGET_BRANCH
+fi
 
 TEMP_WP_ANDROID_DIRECTORY=$(mktemp -d)
 ohai "Clone WordPress-Android into '$TEMP_WP_ANDROID_DIRECTORY'"
-execute "git" "clone" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-Android.git" "$TEMP_WP_ANDROID_DIRECTORY"
+execute "git" "clone" "-b" "$WPANDROID_TARGET_BRANCH" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-Android.git" "$TEMP_WP_ANDROID_DIRECTORY"
 
 cd "$TEMP_WP_ANDROID_DIRECTORY"
 
@@ -305,9 +311,15 @@ echo ""
 # WPiOS PR
 #####
 
+read -p "Do you want to target $WPIOS_TARGET_BRANCH branch for WPiOS PR? (y/n) " -n 1
+echo ""
+if [[ $REPLY =~ ^[Nn]$ ]]; then
+    read -p "Enter the branch name you want to target. Make sure a branch with this name already exists in WPiOS repository: " WPIOS_TARGET_BRANCH
+fi
+
 TEMP_WP_IOS_DIRECTORY=$(mktemp -d)
 ohai "Clone WordPress-iOS into '$TEMP_WP_IOS_DIRECTORY'"
-execute "git" "clone" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-iOS.git" "$TEMP_WP_IOS_DIRECTORY"
+execute "git" "clone" "-b" "$WPIOS_TARGET_BRANCH" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-iOS.git" "$TEMP_WP_IOS_DIRECTORY"
 
 cd "$TEMP_WP_IOS_DIRECTORY"
 

--- a/release_utils.sh
+++ b/release_utils.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-# Accepts the repository owner/name (wordpress-mobile/gutenberg-mobile) and returns
-# the locally matching remote
-function get_remote_name() {
-    REPO="$1"
-    git remote -v | grep "git@github.com:$REPO.git (push)" | grep -oE '^\S*'
-}
-
-
 # Utils adapted from https://github.com/Homebrew/install/blob/master/install.sh
 # string formatters
 if [[ -t 1 ]]; then


### PR DESCRIPTION
- Use same PR body for both WPApps
- Use --head parameter when creating PRs with GitHub CLI to fix errors
- Add the capability to target different base branches for main app PRs
- Add option to cherry-pick a commit from gutenberg before bundling
- Separate commit messages for bundle and gutenberg ref update