### PR TITLE
Tweak template usage instructions to separate title and body

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -12,14 +12,17 @@ This is useful in case you want to use an unreleased version of the bundle in th
 
 # Release Checklist Template
 
-Just copy this checklist and replace all occurrences of `X.XX.X` with the applicable release number, when we are ready to
-cut a new release.
+When you are ready to cut a new release, use the following template.
+
+For the post title, use this (replacing `X.XX.X` with the applicable release number):
 
 ```
-<!-- wp:heading {"level":1} -->
-<h1>Gutenberg Mobile X.XX.X – Release Scenario</h1>
-<!-- /wp:heading -->
+Gutenberg Mobile X.XX.X – Release Scenario
+```
 
+For the body of the post, just copy this checklist and again replace all occurrences of `X.XX.X` with the applicable release number.
+
+```
 <!-- wp:paragraph -->
 <p>This checklist is based on the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/develop/Releasing.md#release-checklist-template">Release Checklist Template</a>. If you need a checklist for a new gutenberg-mobile release, please copy from that template.</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
When using this template, I made the mistake of copying the title into the post body instead of as a separate post title. So this change aims to make that more clearer and avoid posts with empty titles.