### PR TITLE
Update branch name from main to trunk

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -105,7 +105,7 @@ cut a new release.
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Merge the Gutenberg-Mobile PR to main. WARNING: Don’t merge the Gutenberg PR to master at this point.</p>
+<p>o Merge the Gutenberg-Mobile PR to `trunk`. WARNING: Don’t merge the Gutenberg PR to master at this point.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/Releasing.md
+++ b/Releasing.md
@@ -105,7 +105,7 @@ cut a new release.
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Merge the Gutenberg-Mobile PR to `trunk`. WARNING: Don’t merge the Gutenberg PR to master at this point.</p>
+<p>o Merge the Gutenberg-Mobile PR to <code>trunk</code>. WARNING: Don’t merge the Gutenberg PR to master at this point.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
Since we're using the branch name `trunk` instead of `main`, this updates the docs to reflect that.