### PR TITLE
Dont fail if no changes after bundle update

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -174,7 +174,7 @@ npm run bundle || abort "Error: 'npm bundle' failed.\nIf there is an error stati
 # Commit bundle changes
 ohai "Commit bundle changes"
 execute "git" "add" "bundle/"
-execute "git" "commit" "-m" "Release script: Update bundle for: $VERSION_NUMBER"
+execute "git" "diff-index" "--quiet" "HEAD" "||" "git" "commit" "-m" "Release script: Update bundle for: $VERSION_NUMBER"
 
 
 #####


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/14

To test:

Script should not fail if there are no bundle updates. 