### PR TITLE
Tweak cmd that checks if bundle needs to be commit

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -174,7 +174,7 @@ npm run bundle || abort "Error: 'npm bundle' failed.\nIf there is an error stati
 # Commit bundle changes
 ohai "Commit bundle changes"
 execute "git" "add" "bundle/"
-execute "git" "diff-index" "--quiet" "HEAD" "||" "git" "commit" "-m" "Release script: Update bundle for: $VERSION_NUMBER"
+execute "git" "diff-index" "--quiet" "HEAD" "--" "." "||" "git" "commit" "-m" "Release script: Update bundle for: $VERSION_NUMBER"
 
 
 #####


### PR DESCRIPTION
A tweak to the https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/15 PR which fixes an issue that looks like this:
```
==> Commit bundle changes
fatal: ambiguous argument '||': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

Failed during: git diff-index --quiet HEAD || git commit -m Release\ script:\ Update\ bundle\ for:\ 1.44.0
```