### PR TITLE
Remove check for no changes to bundle, it is breaking standard command

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -174,7 +174,7 @@ npm run bundle || abort "Error: 'npm bundle' failed.\nIf there is an error stati
 # Commit bundle changes
 ohai "Commit bundle changes"
 execute "git" "add" "bundle/"
-execute "git" "diff-index" "--quiet" "HEAD" "--" "." "||" "git" "commit" "-m" "Release script: Update bundle for: $VERSION_NUMBER"
+execute "git" "commit" "-m" "Release script: Update bundle for: $VERSION_NUMBER"
 
 
 #####


### PR DESCRIPTION
Temporarily removing check for no bundle changes because is is breaking the stand bundle generation command. 