### PR TITLE
Add --tab option to jq updating package.json files

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -121,7 +121,7 @@ cd ..
 ohai "Set version numbers in package.json files"
 for file in 'package.json' 'package-lock.json' 'gutenberg/packages/react-native-aztec/package.json' 'gutenberg/packages/react-native-bridge/package.json' 'gutenberg/packages/react-native-editor/package.json'; do
     TEMP_FILE=$(mktemp)
-    execute "jq" ".version = \"$VERSION_NUMBER\"" "$file" > "$TEMP_FILE"
+    execute "jq" ".version = \"$VERSION_NUMBER\"" "$file" > "$TEMP_FILE" "--tab"
     execute "mv" "$TEMP_FILE" "$file"
 done
 


### PR DESCRIPTION
Gutenberg `package.json` files use tabs and `jq` converts them to spaces when modifying. Adding `--tab` option should fix this.

To test: 

In `gutenberg` or `gutenberg-mobile` run:

```sh
"jq" ".version = 9.99" "package.json" > "temp.json" --tab
"mv" "temp.json" "package.json"
```

Check if `package.json` has tabs.