### PR TITLE
Check if GitHub CLI is logged

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -60,6 +60,9 @@ cd "$GB_MOBILE_PATH"
 # Check that Github CLI is installed
 command -v gh >/dev/null || abort "Error: The Github CLI must be installed."
 
+# Check that Github CLI is logged
+gh auth status >/dev/null 2>&1 || abort "Error: You are not logged into any GitHub hosts. Run gh auth login to authenticate."
+
 # Check that jq is installed
 command -v jq >/dev/null || abort "Error: jq must be installed."
 

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -61,7 +61,7 @@ cd "$GB_MOBILE_PATH"
 command -v gh >/dev/null || abort "Error: The Github CLI must be installed."
 
 # Check that Github CLI is logged
-gh auth status >/dev/null 2>&1 || abort "Error: You are not logged into any GitHub hosts. Run gh auth login to authenticate."
+gh auth status >/dev/null 2>&1 || abort "Error: You are not logged into any GitHub hosts. Run 'gh auth login' to authenticate."
 
 # Check that jq is installed
 command -v jq >/dev/null || abort "Error: jq must be installed."


### PR DESCRIPTION
## Description
The first time I run the release script I forgot to log in and the process failed in the last steps without the option to re-run it again because it already made modifications. For preventing this situation in the future, the idea is to just check if the GitHub CLI is logged and if not abort the process before the script executes more commands.

## How to test
### Preparation
These changes are hard to test this without actually running the script. So for only test the part that is modified, a line should be added after the check with `exit`, it will look like:
```
...
# Check that Github CLI is logged
gh auth status >/dev/null 2>&1 || abort "Error: You are not logged into any GitHub hosts. Run gh auth login to authenticate."

exit
...
```

**⚠️ Please verify that the `exit` line is added before running the script, otherwise release branches could be created.**

### Verify that fails if not logged
1. Logout by running: `gh auth logout`.
2. Run the script: `./release_automation.sh`.
3. Check that the scripts is aborted with the error message.

### Verify that passes if logged
1. Log in by running: `gh auth login`.
2. Run the script: `./release_automation.sh`.
3. Check that the scripts finishes without showing an error.

