### PR TITLE
Update gutenberg to trunk from master

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -16,7 +16,7 @@ WPANDROID_PR_LABEL="gutenberg-mobile"
 WPIOS_PR_LABEL="Gutenberg integration"
 # 3. Ensure that each of your repos contains the target branch listed below:
 GUTENBERG_MOBILE_TARGET_BRANCH="trunk"
-GUTENBERG_TARGET_BRANCH="master"
+GUTENBERG_TARGET_BRANCH="trunk"
 WPANDROID_TARGET_BRANCH="develop"
 WPIOS_TARGET_BRANCH="develop"
 # 4. Update the repo names below to the user repo name for your fork


### PR DESCRIPTION
Since the gutenberg repo switched from master to trunk for its main github branch. 
This PR makes the switch as well. 