### PR TITLE
Proposal: Remove develop branch

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -112,15 +112,11 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Merge the Gutenberg-Mobile PR to <code>trunk</code>. WARNING: Don’t merge the Gutenberg PR to <code>trunk</code> at this point.</p>
+<p>o Create a new GitHub release pointing to the tag: https://github.com/wordpress-mobile/gutenberg-mobile/releases/new?tag=vX.XX.X&target=release/X.XX.X&title=Release%20X.XX.X. Include a list of changes in the release's description</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>o Tag the head of Gutenberg release branch that the Gutenberg-Mobile release branch is pointing to with the <code>rnmobile/X.XX.X</code> tag.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>o Create a new GitHub release pointing to the tag: https://github.com/wordpress-mobile/gutenberg-mobile/releases/new?tag=vX.XX.X&target=trunk&title=Release%20X.XX.X. Include a list of changes in the release's description</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -144,11 +140,15 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
+<p>o If there are any conflicts in the Gutenberg-Mobile PR, merge <code>trunk</code> into it and resolve them.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
 <p>o If there are any conflicts in the Gutenberg PR, merge <code>trunk</code> into it and resolve them.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Merge the Gutenberg PR to <code>trunk</code>.</p>
+<p>o Merge the Gutenberg PR to <code>trunk</code> and Gutenberg-Mobile PR to <code>trunk</code>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->

--- a/Releasing.md
+++ b/Releasing.md
@@ -148,15 +148,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Check if you can open a PR from <code>trunk</code> to <code>develop</code> in Gutenberg Mobile without any conflicts: https://github.com/wordpress-mobile/gutenberg-mobile/compare/develop...trunk. If there are any conflicts, create a branch from <code>trunk</code> with a name like <code>merge_release_x.xx.x_to_develop</code>, merge <code>develop</code> into it, resolve any conflicts.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>o Open a PR from Gutenberg Mobile <code>trunk</code> (or <code>merge_release_x.xx.x_to_develop</code> branch) to <code>develop</code>.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>o Merge the Gutenberg PR to <code>trunk</code> and Gutenberg Mobile PR to <code>develop</code>.</p>
+<p>o Merge the Gutenberg PR to <code>trunk</code>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
@@ -195,7 +187,7 @@ For example when releasing gutenberg-mobile `1.11.0`.
 | Repo             | Cut From | Branch Name                        | Merging To      |
 | ---------------- | -------- | ---------------------------------- | --------------- |
 | gutenberg        | trunk    | rnmobile/release_1.11.0            | trunk           |
-| gutenberg-mobile | develop  | release/1.11.0                     | trunk & develop |
+| gutenberg-mobile | trunk    | release/1.11.0                     | trunk           |
 | WPAndroid        | develop  | gutenberg/integrate_release_1.11.0 | develop         |
 | WPiOS            | develop  | gutenberg/integrate_release_1.11.0 | develop         |
 
@@ -213,7 +205,7 @@ At the same time there could also be a regular release going on for example for 
 | Repo             | Cut From                | Branch Name                        | Merging To                                                       |
 | ---------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------- |
 | gutenberg        | rnmobile/release_1.11.0 | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.0                     |
-| gutenberg-mobile | release/1.11.0          | release/1.11.1                     | trunk & develop & (maybe also) release/1.12.0                    |
+| gutenberg-mobile | release/1.11.0          | release/1.11.1                     | trunk & (maybe also) release/1.12.0                              |
 | WPAndroid        | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.0 & (maybe also) gutenberg/integrate_release_1.12.0 |
 | WPiOS            | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.0 & (maybe also) gutenberg/integrate_release_1.12.0 |
 
@@ -243,7 +235,7 @@ At the same time there could also be a regular release, a betafix or even anothe
 | Repo             | Cut From                | Branch Name                        | Merging To                                                       |
 | ---------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------- |
 | gutenberg        | rnmobile/release_1.11.0 | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.1                     |
-| gutenberg-mobile | release/1.11.0          | release/1.11.1                     | trunk & develop & (maybe also) release/1.12.1                    |
+| gutenberg-mobile | release/1.11.0          | release/1.11.1                     | trunk & (maybe also) release/1.12.1                              |
 | WPAndroid        | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.1 & (maybe also) gutenberg/integrate_release_1.12.1 |
 | WPiOS            | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.1 & (maybe also) gutenberg/integrate_release_1.12.1 |
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -165,7 +165,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Merge the Gutenberg-Mobile PR to <code>trunk</code>.</p>
+<p>o Merge the Gutenberg PR to <code>trunk</code>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->


### PR DESCRIPTION
This is a proposal to switch Gutenberg Mobile over from a Git Flow to a "GitHub Flow" branch workflow.

Instead of using both a `develop` and a `trunk` branch as we currently do, we could instead use the same branch model Gutenberg uses where a single `trunk` branch contains code that has passed review ([this Gutenberg doc roughly describes the flow](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/git-workflow.md)).

Gutenberg Mobile releases will still be specified by tagged commits on the `trunk` branch. 

### Why

We often have multiple Gutenberg Releases "in action". For example, at time of writing `1.47.2` (a hotfix) is in the current production version of the main apps (16.8) while `1.48.1` (a betafix) is in the current beta version of the main apps (16.9). If the need for another release arises we can't simply look at `trunk` to say "that's what we should base our new release off". So instead we consider whether this is a hotfix or a betafix and find the appropriate tag to create our new release off of. This means that in practice, we don't normally look at the `trunk` branch – it's tags we use to know what code is in what release.

### Upsides
- Simplified branching model
- The Gutenberg Mobile release branches would only need to be merged back to `trunk` (instead of `trunk` and `develop`)
- We'd move this project closer to Gutenberg by adopting its branching model
- One less branch to wrangle

### Downsides
- Release tags would still happen on `trunk` in Gutenberg Mobile, normal feature branches would also be merged there, too. So if keeping a separate branch only for releases is useful, this change could be a negative in that regard.

### Changes needed
- [x] Update release checklist template
- [ ] Update release scripts
- [ ] Update [CircleCI config](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/.circleci/config.yml)
- [ ] Change the Gutenberg Mobile default branch from `develop` to `trunk`

