### PR TITLE
Clarify that release script should always be used

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -12,7 +12,7 @@ This is useful in case you want to use an unreleased version of the bundle in th
 
 # Release Checklist Template
 
-When you are ready to cut a new release, use the template found below. It specifies the use of an automation script which handles the creation of release branches. It's best practice to use this script for all releases types (regular, betafix, hotfix). When wrangling a betafix or hotfix, the actual fix should be merged to `trunk` before the release is cut. This helps ensure that fixes are always included in all subsequent releases, especially in scenarios where multiple releases are cut in a short timeframe.
+When you are ready to cut a new release, use the following template.
 
 For the post title, use this (replacing `X.XX.X` with the applicable release number):
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -12,7 +12,7 @@ This is useful in case you want to use an unreleased version of the bundle in th
 
 # Release Checklist Template
 
-When you are ready to cut a new release, use the following template.
+When you are ready to cut a new release, use the template found below. It specifies the use of an automation script which handles the creation of release branches. It's best practice to use this script for all releases types (regular, betafix, hotfix). When wrangling a betafix or hotfix, the actual fix should be merged to `trunk` before the release is cut. This helps ensure that fixes are always included in all subsequent releases, especially in scenarios where multiple releases are cut in a short timeframe.
 
 For the post title, use this (replacing `X.XX.X` with the applicable release number):
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -182,6 +182,10 @@ For the body of the post, just copy this checklist and again replace all occurre
 
 # Different types of releases
 
+## Best practices
+
+When you are ready to cut a new release, use the template found above. It specifies the use of an automation script which handles the creation of release branches. It's best practice to use this script for all releases types (regular, betafix, hotfix). When wrangling a betafix or hotfix, it's important to merge the fix to Gutenberg `trunk` independently of the release process. When the release is cut (by the automation script) the commit(s) that make up the betafix or hotfix should then be cherry-picked onto the Gutenberg release branch.
+
 ## 1. Regular
 
 ### When

--- a/Releasing.md
+++ b/Releasing.md
@@ -184,7 +184,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 
 ## Best practices
 
-When you are ready to cut a new release, use the template found above. It specifies the use of an automation script which handles the creation of release branches. It's best practice to use this script for all releases types (regular, betafix, hotfix). When wrangling a betafix or hotfix, it's important to merge the fix to Gutenberg `trunk` independently of the release process. When the release is cut (by the automation script) the commit(s) that make up the betafix or hotfix should then be cherry-picked onto the Gutenberg release branch.
+It's best practice to use the automation script (mentioned in the release template above) for all releases types (regular, betafix, hotfix). When wrangling a betafix or hotfix, it's important to merge the fix to Gutenberg `trunk` independently of the release process. When the release is cut (by the automation script) the commit(s) that make up the betafix or hotfix should then be cherry-picked onto the Gutenberg release branch.
 
 ## 1. Regular
 


### PR DESCRIPTION
This PR clarifies that the automation scripts should always be used and betafixes and hotfixes should be merged to Gutenberg `trunk` before running the release scripts.