### PR TITLE
Add a step related to update the Gutenberg reference

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -156,7 +156,15 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Merge the Gutenberg PR to <code>trunk</code> and Gutenberg Mobile PR to <code>develop</code>.</p>
+<p>o Merge the Gutenberg PR to <code>trunk</code>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>o Update the Gutenberg reference in the Gutenberg Mobile PR so it points to the Gutengerg PR merge commit in <code>trunk</code>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>o Merge the Gutenberg PR to <code>trunk</code>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->

--- a/Releasing.md
+++ b/Releasing.md
@@ -160,7 +160,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Update the Gutenberg reference in the Gutenberg Mobile PR so it points to the Gutengerg PR merge commit in <code>trunk</code>.</p>
+<p>o Update the Gutenberg reference in the Gutenberg Mobile PR so it points to the Gutenberg PR merge commit in <code>trunk</code>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
This PR adds a new step in the release process in relation to update the Gutenberg reference after merging the Gutenberg PR into `trunk`.

The idea is that when we bring the release changes back to the development branches we assure that the Gutenberg reference is also updated and therefore that include the changes from Gutenberg.