### PR TITLE
Updated WP Android's gb tag reference instructions

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -136,7 +136,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o In WPAndroid, update the submodule to point to the merge commit on GB-Mobile <code>trunk</code>.</p>
+<p>o In WPAndroid, update the `gutenbergMobileVersion` in `build.gradle` to point to the <em>tag</em>.</p>
 <!-- /wp:paragraph -->
 
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -136,7 +136,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o In WPAndroid, update the `gutenbergMobileVersion` in `build.gradle` to point to the <em>tag</em>.</p>
+<p>o In WPAndroid, update the <code>gutenbergMobileVersion</code> in <code>build.gradle</code> to point to the <em>tag</em>.</p>
 <!-- /wp:paragraph -->
 
 


### PR DESCRIPTION
Due to the binary build changes introduced, we no longer utilize a submodule for  the `gutenberg-mobile` reference in WP Android so this PR seeks to address this by updating the instructions for setting the tag during a release.