### PR TITLE
Fix typo about which PR to merge to which branch

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -177,7 +177,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Merge the Gutenberg PR to <code>trunk</code>.</p>
+<p>o Merge the Gutenberg Mobile PR to <code>develop</code>.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->


### PR DESCRIPTION
The step that should say to merge the Gutenberg Mobile PR that brings changes from `trunk` to `develop` incorrectly says to merge the Gutenberg PR to `trunk`.