### PR TITLE
Update the release automation script to update the version in build.gradle

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -288,12 +288,15 @@ execute "git" "push" "-u" "origin" "HEAD"
 ohai "Create release branch in WordPress-Android"
 execute "git" "switch" "-c" "$WP_APPS_INTEGRATION_BRANCH"
 
+# Explodes the PR url with the second parameter being the PR ID. 
+PULL_ID_ARR=(${GB_MOBILE_PR_URL//pull\// })
+
 ohai "Update build.gradle file with the latest version"
 test -f "build.gradle" || abort "Error: Could not find build.gradle"
-sed -i'.orig' -E "s/ext.gutenbergMobileVersion = '(.*)'/ext.gutenbergMobileVersion = 'v$VERSION_NUMBER'/" build.gradle || abort "Error: Failed updating gutenbergMobileVersion in build.gradle"
+sed -i'.orig' -E "s/ext.gutenbergMobileVersion = '(.*)'/ext.gutenbergMobileVersion = '${PULL_ID_ARR[1]}-$GB_MOBILE_PR_REF'/" build.gradle || abort "Error: Failed updating gutenbergMobileVersion in build.gradle"
 
 execute "git" "add" "build.gradle"
-execute "git" "commit" "-m" "Release script: Update build.gradle gutenbergMobileVersion version to $VERSION_NUMBER"
+execute "git" "commit" "-m" "Release script: Update build.gradle gutenbergMobileVersion to ref"
 
 ohai "Update strings"
 execute "python" "tools/merge_strings_xml.py"

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # INSTRUCTIONS FOR TESTING FROM FORKED REPOS
-# Prerequisites: 
+# Prerequisites:
 # 1. Fork the following repos to your github user repo:
 #    a) Gutenberg-Mobile: https://github.com/wordpress-mobile/gutenberg-mobile
-#    * .gitmodules on CURRENT_BRANCH should reference your gutenberg fork, replace 'WordPress' with GITHUB_USERNAME 
+#    * .gitmodules on CURRENT_BRANCH should reference your gutenberg fork, replace 'WordPress' with GITHUB_USERNAME
 #    * (https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/.gitmodules)
 #    b) Gutenberg: https://github.com/WordPress/gutenberg
 #    c) WordPress-Android: https://github.com/wordpress-mobile/WordPress-Android
@@ -22,8 +22,8 @@ WPIOS_TARGET_BRANCH="develop"
 # 4. Update the repo names below to the user repo name for your fork
 GUTENBERG_REPO="WordPress"
 MOBILE_REPO="wordpress-mobile"
-#GUTENBERG_REPO="YOUR_GITHUB_USERNAME"
-#MOBILE_REPO="YOUR_GITHUB_USERNAME"
+# GUTENBERG_REPO="YOUR_GITHUB_USERNAME"
+# MOBILE_REPO="YOUR_GITHUB_USERNAME"
 # 5. Clone the forked gutenberg-mobile repo
 
 # Before creating the release, this script performs the following checks:
@@ -111,13 +111,13 @@ fi
 # Create Git branch
 RELEASE_BRANCH="release/$VERSION_NUMBER"
 ohai "Create Git branch '$RELEASE_BRANCH' in gutenberg-mobile."
-execute "git" "switch" "-c" "$RELEASE_BRANCH" 
+execute "git" "switch" "-c" "$RELEASE_BRANCH"
 
 # Create Git branch in Gutenberg
 GB_RELEASE_BRANCH="rnmobile/release_$VERSION_NUMBER"
 ohai "Create Git branch '$GB_RELEASE_BRANCH' in gutenberg."
 cd gutenberg
-execute "git" "switch" "-c" "$GB_RELEASE_BRANCH" 
+execute "git" "switch" "-c" "$GB_RELEASE_BRANCH"
 cd ..
 
 # Set version numbers
@@ -214,7 +214,7 @@ GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" \
 # Get Checklist from Gutenberg PR template
 cd gutenberg
 GUTENBERG_PR_TEMPLATE_PATH=".github/PULL_REQUEST_TEMPLATE.md"
-test -f "$GUTENBERG_PR_TEMPLATE_PATH" || abort "Error: Could not find PR template at $GUTENBERG_PR_TEMPLATE_PATH" 
+test -f "$GUTENBERG_PR_TEMPLATE_PATH" || abort "Error: Could not find PR template at $GUTENBERG_PR_TEMPLATE_PATH"
 # Get the checklist from the gutenberg PR template by removing everything before the '## Checklist:' line
 CHECKLIST_FROM_GUTENBERG_PR_TEMPLATE=$(sed -e/'## Checklist:'/\{ -e:1 -en\;b1 -e\} -ed < "$GUTENBERG_PR_TEMPLATE_PATH")
 
@@ -252,7 +252,7 @@ GB_MOBILE_PR_REF=$(git rev-parse HEAD)
 WP_APPS_PR_TITLE="Integrate gutenberg-mobile release $VERSION_NUMBER"
 
 WP_APPS_PR_BODY="## Description
-This PR incorporates the $VERSION_NUMBER release of gutenberg-mobile.  
+This PR incorporates the $VERSION_NUMBER release of gutenberg-mobile.
 For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: $GB_MOBILE_PR_URL
 
 Release Submission Checklist
@@ -281,7 +281,7 @@ cd "$TEMP_WP_ANDROID_DIRECTORY"
 execute "git" "submodule" "update" "--init" "--recursive" "--depth=1" "--recommend-shallow"
 
 ohai "Create after_x.xx.x branch in WordPress-Android"
-execute "git" "switch" "-c" "gutenberg/after_$VERSION_NUMBER" 
+execute "git" "switch" "-c" "gutenberg/after_$VERSION_NUMBER"
 
 execute "git" "push" "-u" "origin" "HEAD"
 
@@ -332,12 +332,12 @@ execute "git" "clone" "-b" "$WPIOS_TARGET_BRANCH" "--depth=1" "git@github.com:$M
 cd "$TEMP_WP_IOS_DIRECTORY"
 
 ohai "Create after_x.xx.x branch in WordPress-iOS"
-execute "git" "switch" "-c" "gutenberg/after_$VERSION_NUMBER" 
+execute "git" "switch" "-c" "gutenberg/after_$VERSION_NUMBER"
 
 execute "git" "push" "-u" "origin" "HEAD"
 
 ohai "Create release branch in WordPress-iOS"
-execute "git" "switch" "-c" "gutenberg/integrate_release_$VERSION_NUMBER" 
+execute "git" "switch" "-c" "gutenberg/integrate_release_$VERSION_NUMBER"
 
 ohai "Update GitHub organization and gutenberg-mobile ref"
 test -f "Podfile" || abort "Error: Could not find Podfile"

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -277,7 +277,7 @@ execute "git" "clone" "-b" "$WPANDROID_TARGET_BRANCH" "--depth=1" "git@github.co
 
 cd "$TEMP_WP_ANDROID_DIRECTORY"
 
-# This is still needed bacause of Andorid Stories.
+# This is still needed because of Android Stories.
 execute "git" "submodule" "update" "--init" "--recursive" "--depth=1" "--recommend-shallow"
 
 ohai "Create after_x.xx.x branch in WordPress-Android"
@@ -377,4 +377,3 @@ echo ""
 echo "Main apps PRs created"
 echo "==========="
 printf "WPAndroid %s \n WPiOS %s \n" "$WP_ANDROID_PR_URL" "$WP_IOS_PR_URL" | column -t
-

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -298,17 +298,6 @@ sed -i'.orig' -E "s/ext.gutenbergMobileVersion = '(.*)'/ext.gutenbergMobileVersi
 execute "git" "add" "build.gradle"
 execute "git" "commit" "-m" "Release script: Update build.gradle gutenbergMobileVersion to ref"
 
-ohai "Update strings"
-execute "python" "tools/merge_strings_xml.py"
-# If merge_strings_xml.py results in changes, commit them
-if [[ -n "$(git status --porcelain)" ]]; then
-    ohai "Commit changes from 'python tools/merge_strings_xml.py'"
-    execute "git" "add" "WordPress/src/main/res/values/strings.xml"
-    execute "git" "commit" "-m" "Release script: Update strings"
-else
-    ohai "There were no changes from 'python tools/merge_strings_xml.py' to be committed."
-fi
-
 ohai "Push integration branch"
 execute "git" "push" "-u" "origin" "HEAD"
 

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -288,12 +288,12 @@ execute "git" "push" "-u" "origin" "HEAD"
 ohai "Create release branch in WordPress-Android"
 execute "git" "switch" "-c" "$WP_APPS_INTEGRATION_BRANCH"
 
-# Explodes the PR url with the second parameter being the PR ID. 
-PULL_ID_ARR=(${GB_MOBILE_PR_URL//pull\// })
+# Get the last part of the path from GB_MOBILE_PR_URL
+PULL_ID=${GB_MOBILE_PR_URL##*/}
 
 ohai "Update build.gradle file with the latest version"
 test -f "build.gradle" || abort "Error: Could not find build.gradle"
-sed -i'.orig' -E "s/ext.gutenbergMobileVersion = '(.*)'/ext.gutenbergMobileVersion = '${PULL_ID_ARR[1]}-$GB_MOBILE_PR_REF'/" build.gradle || abort "Error: Failed updating gutenbergMobileVersion in build.gradle"
+sed -i'.orig' -E "s/ext.gutenbergMobileVersion = '(.*)'/ext.gutenbergMobileVersion = '${PULL_ID}-$GB_MOBILE_PR_REF'/" build.gradle || abort "Error: Failed updating gutenbergMobileVersion in build.gradle"
 
 execute "git" "add" "build.gradle"
 execute "git" "commit" "-m" "Release script: Update build.gradle gutenbergMobileVersion to ref"

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -277,6 +277,7 @@ execute "git" "clone" "-b" "$WPANDROID_TARGET_BRANCH" "--depth=1" "git@github.co
 
 cd "$TEMP_WP_ANDROID_DIRECTORY"
 
+# This is still needed bacause of Andorid Stories.
 execute "git" "submodule" "update" "--init" "--recursive" "--depth=1" "--recommend-shallow"
 
 ohai "Create after_x.xx.x branch in WordPress-Android"
@@ -287,15 +288,12 @@ execute "git" "push" "-u" "origin" "HEAD"
 ohai "Create release branch in WordPress-Android"
 execute "git" "switch" "-c" "$WP_APPS_INTEGRATION_BRANCH"
 
-ohai "Update gutenberg-mobile ref"
-cd libs/gutenberg-mobile
-execute "git" "fetch" "--recurse-submodules=no" "origin" "$GB_MOBILE_PR_REF"
-execute "git" "checkout" "$GB_MOBILE_PR_REF"
-execute "git" "submodule" "update"
-cd ../..
+ohai "Update build.gradle file with the latest version"
+test -f "build.gradle" || abort "Error: Could not find build.gradle"
+sed -i'.orig' -E "s/ext.gutenbergMobileVersion = '(.*)'/ext.gutenbergMobileVersion = 'v$VERSION_NUMBER'/" build.gradle || abort "Error: Failed updating gutenbergMobileVersion in build.gradle"
 
-execute "git" "add" "libs/gutenberg-mobile"
-execute "git" "commit" "-m" "Release script: Update gutenberg-mobile ref"
+execute "git" "add" "build.gradle"
+execute "git" "commit" "-m" "Release script: Update build.gradle gutenbergMobileVersion version to $VERSION_NUMBER"
 
 ohai "Update strings"
 execute "python" "tools/merge_strings_xml.py"


### PR DESCRIPTION
This PR updates the release_automation.sh script to account for the new android app release process as described in pbMoDN-2gI-p2. 

It does this by replacing the submodule (there is no submodule any more) ref updating with updating the string in `build.gradle`. 

# How has this been tested?
I created a helper script. 
```
#!/bin/bash

set -e

# Utils adapted from https://github.com/Homebrew/install/blob/master/install.sh
# string formatters
if [[ -t 1 ]]; then
    tty_escape() { printf "\033[%sm" "$1"; }
else
    tty_escape() { :; }
fi
tty_mkbold() { tty_escape "1;$1"; }
tty_underline="$(tty_escape "4;39")"
tty_blue="$(tty_mkbold 34)"
tty_red="$(tty_mkbold 31)"
tty_reset="$(tty_escape 0)"


# Takes multiple arguments and prints them joined with single spaces in-between
# while escaping any spaces in arguments themselves
shell_join() {
    local arg
    printf "%s" "$1"
    shift
    for arg in "$@"; do
        printf " "
        printf "%s" "${arg// /\ }"
    done
}

# Takes multiple arguments, joins them and prints them in a colored format
ohai() {
  printf "${tty_blue}==> %s${tty_reset}\n" "$(shell_join "$@")"
}

# Takes a single argument, prints it in a colored format and aborts the script
abort() {
    printf "\n${tty_red}%s${tty_reset}\n" "$1"
    exit 1
}

# Check that Aztec versions are set to release versions
read -r -p "Enter the new version number: " VERSION_NUMBER
if [[ -z "$VERSION_NUMBER" ]]; then
    abort "Version number cannot be empty."
fi

# Update build.gradle with the latest version.
test -f "build.gradle" || abort "Error: Could not find build.gradle"
sed -i'.orig' -E "s/ext.gutenbergMobileVersion = '(.*)'/ext.gutenbergMobileVersion = '$VERSION_NUMBER'/" build.gradle || abort "Error: Failed updating gutenbergMobileVersion in build.gradle"

echo "END build.gradle updated";
```

That I then executed on the WordPress-Android Repo. 
Then confirmed that the version in the `build.gradle` file looked as expected.
