### PR TITLE
Add UBE testing to release checklist

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -76,6 +76,26 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
+<h3>Release Testing</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>o Use the main WP apps to test the new changes in the PR</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>o Smoke test the main WP apps for <a href="https://github.com/wordpress-mobile/test-cases/tree/master/test-cases/gutenberg/writing-flow">general writing flow</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>o Test the Unsupported Block Editor on WP Apps (<a href="https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/unsupported-block-editing.md#unsupported-block-editing---test-cases">see steps</a>).</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>o Sanity <a href="https://github.com/wordpress-mobile/test-cases/blob/trunk/test-suites/gutenberg/sanity-test-suites.md">test suites</a> for WP Apps should be completed for each platform. (See <a href="https://mobilegutenpagesp2.wordpress.com/sanity-testing-rotations/">testing schedule</a>)</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
 <h3>New Aztec Release</h3>
 <!-- /wp:heading -->
 

--- a/release_pull_request.md
+++ b/release_pull_request.md
@@ -14,19 +14,22 @@ Release for Gutenberg Mobile v1.XX.Y
 No extra PRs yet. 🎉
 
 ## Changes
+
 <!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->
 
- - Change 1: link-to-pr-describing-change-1
- - Change 2: link-to-pr-describing-change-2
+- Change 1: link-to-pr-describing-change-1
+- Change 2: link-to-pr-describing-change-2
 
 ## Test plan
 
-- Use the main WP apps to test the changes above. 
+- Use the main WP apps to test the changes above.
 - Smoke test the main WP apps for [general writing flow](https://github.com/wordpress-mobile/test-cases/tree/master/test-cases/gutenberg/writing-flow).
+- Test the Unsupported Block Editor on WP Apps ([see steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/unsupported-block-editing.md#unsupported-block-editing---test-cases)).
+- Sanity [test suites](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-suites/gutenberg/sanity-test-suites.md) for WP Apps should be completed for each platform.
 
 ## Release Submission Checklist
 
+- [ ] Verify Items from test plan have been completed
 - [ ] Approve and run optional Android and iOS UI tests
 - [ ] Check if `RELEASE-NOTES.txt` and `gutenberg/packages/react-native-editor/CHANGELOG.md` are updated with all the changes that made it to the release.
 - [ ] Bundle package of the release is updated.
-


### PR DESCRIPTION
After discovering this UBE issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3349, we realized UBE was left out of existing release test suites, and we decided to add [UBE manual testing](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/unsupported-block-editing.md) to every release. 

I also added some details so that our current testing steps were explicitly added to the P2 checklist and the release PR checklist. 