### PR TITLE
New WordPress Apps gutenberg ref update PRs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ brew install jq
 
 ## Usage
 
-Run the script: `./release_automation.sh`
+### Release Script
+- Run the script: `./release_automation.sh`
+- See [Releasing.md](./Releasing.md) for more details
+
+### WordPress Gutenberg Reference Update Automation
+- Run the script: `./wp_gutenberg_ref_update_prs.sh`
+- See [WordPressApps_Gutenberg_Reference_Update.md](./WordPressApps_Gutenberg_Reference_Update.md) for more details
 
 ## Testing
 

--- a/WordPressApps_Gutenberg_Reference_Update.md
+++ b/WordPressApps_Gutenberg_Reference_Update.md
@@ -82,7 +82,7 @@ Prior to generating gutenberg mobile bundle we run a `npm run core preios` comma
 
 ### Why not just use the exising `./release_automation.sh` script for generating builds?
 
-The  `./release_automation.sh` includes extra checks for making sure that gutenberg-mobile branch is ready for generating a release. Some of these checks would prevent quickly running the script against a non release ready branch for quickly generating WPApps test PRs. See [here](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/d718e1c0732f1c422d427f0fbe0eaa968f978da9/release_automation.sh#L29).
+The  `./release_automation.sh` includes extra checks for making sure that gutenberg-mobile branch is ready for generating a release. Some of these checks would prevent quickly running the script against a non release ready branch for quickly generating WPApps test PRs. See [here](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/d718e1c0732f1c422d427f0fbe0eaa968f978da9/release_automation.sh#L29). Separate scripts for regular WP Apps integration versus gutenberg-mobile releases also allows for further optimization and experimentation with `./wp_gutenberg_ref_update_prs.sh` without breaking the release process.
 
 ### My WordPress-Android PR has failed CI for missing gutenberg-mobile bridge on S3, why?
 

--- a/WordPressApps_Gutenberg_Reference_Update.md
+++ b/WordPressApps_Gutenberg_Reference_Update.md
@@ -35,7 +35,7 @@ brew install jq
 git clone git@github.com:wordpress-mobile/release-toolkit-gutenberg-mobile.git
 ```
 
-1. Local clone of the gutenberg-mobile repository, checked out to the specific branch that you would like to generate WordPress Apps Pull Requests for.
+3. Local clone of the gutenberg-mobile repository, checked out to the specific branch that you would like to generate WordPress Apps Pull Requests for.
 
 ```sh
 git clone git@github.com:wordpress-mobile/gutenberg-mobile.git

--- a/WordPressApps_Gutenberg_Reference_Update.md
+++ b/WordPressApps_Gutenberg_Reference_Update.md
@@ -1,0 +1,93 @@
+# Generating WordPress-Android/iOS gutenberg reference update PRs
+
+The `./wp_gutenberg_ref_update_prs.sh` script can be used for automatically generating Pull Requests in the [WordPress-Android ](https://github.com/wordpress-mobile/WordPress-Android)and [WordPress-iOS](https://github.com/wordpress-mobile/WordPress-iOS) GitHub repositories that integrate changes from a specific [gutenberg-mobile](https://github.com/wordpress-mobile/gutenberg-mobile) branch. 
+
+---
+
+  - [Preqrequisites](#preqrequisites)
+  - [Usage](#usage)
+  - [Expected Script Runtime (Approximate):](#expected-script-runtime-approximate)
+  - [Testing](#testing)
+  - [FAQ](#faq)
+    - [Why do we need to generate a gutenberg-mobile PR? I just want Apps integration PRs for testing.](#why-do-we-need-to-generate-a-gutenberg-mobile-pr-i-just-want-apps-integration-prs-for-testing)
+    - [Why do we need a gutenberg branch?](#why-do-we-need-a-gutenberg-branch)
+    - [Why not just use the exising `./release_automation.sh` script for generating builds?](#why-not-just-use-the-exising-release_automationsh-script-for-generating-builds)
+    - [My WordPress-Android PR has failed CI for missing gutenberg-mobile bridge on S3, why?](#my-wordpress-android-pr-has-failed-ci-for-missing-gutenberg-mobile-bridge-on-s3-why)
+    - [What do I do if the script exited halfway for some reason?](#what-do-i-do-if-the-script-exited-halfway-for-some-reason)
+
+---
+
+## Preqrequisites:
+
+1. To be able to run the automation scripts make sure you have installed:
+
+[Github CLI](https://github.com/cli/cli)
+```sh
+brew install gh
+```
+[jq](https://github.com/stedolan/jq)
+```sh
+brew install jq
+```
+
+2. Locally clone an up to date version of this release-toolkit-gutenberg-mobile repository (`develop` branch)
+```sh
+git clone git@github.com:wordpress-mobile/release-toolkit-gutenberg-mobile.git
+```
+
+1. Local clone of the gutenberg-mobile repository, checked out to the specific branch that you would like to generate WordPress Apps Pull Requests for.
+
+```sh
+git clone git@github.com:wordpress-mobile/gutenberg-mobile.git
+git checkout <GB_MOBILE_BRANCH_TO_GENERATE_PRS_FROM>
+```
+---
+## Usage
+
+Run the script: `./wp_gutenberg_ref_update_prs.sh`
+
+You will be prompted for:
+1. The local path to your gutenberg-mobile clone (default is sibling directory of script)
+2. The new branch name for your gutenberg-mobile branch that will be used for bundle updates (if branch already exists, script will fail)
+3. The WordPress-Android branch to target (default is `develop`)
+4. The WordPress-iOS branch to target (default is `develop`)
+5. Whether to run `npm ci` in your gutenberg-mobile cloned directory before beginning
+   1. If it is your first time running the script click yes to running `npm ci`
+   2. If you are troubleshooting the script, or you are sure npm dependencies of your gutenberg-mobile local directory are up to date, you can type 'N' to skip this step.
+
+
+The output of the script will be links to PRs in the gutenberg-mobile, WordPress-Android, and WordPress-iOS repositories, as well as the name of a gutenberg repository branch. Don't forget to clean up branches / PRs if they are only used for testing!
+
+---
+## Expected Script Runtime (Approximate):
+
+1. Tested *without* running `npm ci`: ~16 minutes 56s
+2. Tested *with* running  `npm ci`: ~18 minutes 22s
+
+---
+## Testing
+
+If you would like to try out the script before running against the wordpress-mobile GitHub repos, you can follow the instructions at the top of the `./wp_gutenberg_ref_update_prs.sh` script file for running the script against forked repos. 
+
+---
+## FAQ
+
+### Why do we need to generate a gutenberg-mobile PR? I just want Apps integration PRs for testing.
+ 
+ The "[Build Android RN Bridge & Publish to S3](https://github.com/wordpress-mobile/gutenberg-mobile/blob/ed7a64d9d8d82af942f52628ae4b64d8f1010c6a/.circleci/config.yml#L256-L284)" CI job only happens for gutenberg-mobile commits associated with an open PR, and we need that RN Bridge on S3 in order to run WordPress-Android Pull Request CI properly
+
+### Why do we need a gutenberg branch?
+
+Prior to generating gutenberg mobile bundle we run a `npm run core preios` command that may generate Podfile related updates in the gutenberg repo. I think we need to include these changes, but if I am wrong please open a PR to remove this step
+
+### Why not just use the exising `./release_automation.sh` script for generating builds?
+
+The  `./release_automation.sh` includes extra checks for making sure that gutenberg-mobile branch is ready for generating a release. Some of these checks would prevent quickly running the script against a non release ready branch for quickly generating WPApps test PRs. See [here](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/d718e1c0732f1c422d427f0fbe0eaa968f978da9/release_automation.sh#L29).
+
+### My WordPress-Android PR has failed CI for missing gutenberg-mobile bridge on S3, why?
+
+he Gutenberg-Mobile "Build Android RN Bridge & Publish to S3" job on CI must finish before WordPress-Android CI will be able to access the gutenberg mobile bridge from S3. Please verify the "Build Android RN Bridge & Publish to S3" job on your Gutenberg-Mobile PR is finished, and then restart failed tests on your WordPress-Android PR and this failure should go away.
+
+### What do I do if the script exited halfway for some reason?
+
+While troubleshooting, you should return to your pre-script state by navigating to your gutenberg-mobile directory checking out the branch or commit you originally wished to use in your WordPress Apps PRs. You may also need to delete branches locally in you gutenberg-mobile and gutenberg-mobile/gutenberg directories, and delete branches and PRs from the wordpress-mobile (or your fork) GitHub remote repositories. 

--- a/WordPressApps_Gutenberg_Reference_Update.md
+++ b/WordPressApps_Gutenberg_Reference_Update.md
@@ -47,8 +47,8 @@ git checkout <GB_MOBILE_BRANCH_TO_GENERATE_PRS_FROM>
 Run the script: `./wp_gutenberg_ref_update_prs.sh`
 
 You will be prompted for:
-1. The local path to your gutenberg-mobile clone (default is sibling directory of script)
-2. The new branch name for your gutenberg-mobile branch that will be used for bundle updates (if branch already exists, script will fail)
+1. The local path to your gutenberg-mobile clone (press enter for default: sibling directory of script)
+2. The new branch name for your gutenberg-mobile branch that will be used for bundle updates (press enter for default: `$CURRENT_VERSION_NUMBER-$CURRENT_BRANCH-${CURRENT_HASH:0:6}`). Note if branch already exists, script will fail.
 3. The WordPress-Android branch to target (default is `develop`)
 4. The WordPress-iOS branch to target (default is `develop`)
 5. Whether to run `npm ci` in your gutenberg-mobile cloned directory before beginning

--- a/wp_gutenberg_ref_update_prs.sh
+++ b/wp_gutenberg_ref_update_prs.sh
@@ -10,7 +10,7 @@
 #    c) WordPress-Android: https://github.com/wordpress-mobile/WordPress-Android
 #    d) WordPress-iOS: https://github.com/wordpress-mobile/WordPress-iOS
 # 2. Insure that each of your forked repos contains the PR labels specified below:
-GUTENBERG_MOBILE_PR_LABEL="release-process"
+GUTENBERG_MOBILE_PR_LABEL="[Status] DO NOT MERGE"
 WPANDROID_PR_LABEL="gutenberg-mobile"
 WPIOS_PR_LABEL="Gutenberg integration"
 # 3. Ensure that each of your repos contains the target branch listed below:
@@ -50,13 +50,13 @@ gh auth status >/dev/null 2>&1 || abort "Error: You are not logged into any GitH
 # Check that jq is installed
 command -v jq >/dev/null || abort "Error: jq must be installed."
 
-## Check current branch is develop, trunk, or release/* branch
+## Check current branch is what we expect
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 CURRENT_HASH=$(git rev-parse HEAD)
 confirm_to_proceed "Are you sure you want to create WPApps PRs from the gutenberg-mobile '$CURRENT_BRANCH' branch, commit: $CURRENT_HASH ?"
 
 # Confirm branch is clean
-[[ -z "$(git status --porcelain)" ]] || { git status; abort "Uncommitted changes found. Aborting release script..."; }
+[[ -z "$(git status --porcelain)" ]] || { git status; abort "Uncommitted changes found. Aborting WP Integration script..."; }
 
 # Ask for a branch name
 CURRENT_VERSION_NUMBER=$(jq '.version' package.json --raw-output)
@@ -111,7 +111,7 @@ eval "$PRE_IOS_COMMAND"
 cd gutenberg
 if [[ -n "$(git status --porcelain)" ]]; then
     ohai "Commit changes from '$PRE_IOS_COMMAND'"
-    execute "git" "commit" "-a" "-m" "Release script: Update with changes from '$PRE_IOS_COMMAND'"
+    execute "git" "commit" "-a" "-m" "WP Integration script: Update with changes from '$PRE_IOS_COMMAND'"
 else
     ohai "There were no changes from '$PRE_IOS_COMMAND' to be committed."
 fi
@@ -121,7 +121,7 @@ cd ..
 if [[ -n "$(git status --porcelain)" ]]; then
     ohai "Commit updates to gutenberg submodule"
     execute "git" "add" "gutenberg"
-    execute "git" "commit" "-m" "Release script: Update gutenberg ref"
+    execute "git" "commit" "-m" "WP Integration script: Update gutenberg ref"
 else
     ohai "There were no changes from submodule update to be committed."
 fi
@@ -134,7 +134,7 @@ npm run bundle || abort "Error: 'npm bundle' failed.\nIf there is an error stati
 if [[ -n "$(git status --porcelain)" ]]; then
     ohai "Commit bundle changes"
     execute "git" "add" "bundle/"
-    execute "git" "commit" "-m" "Release script: Update bundle for: $BRANCH_NAME"
+    execute "git" "commit" "-m" "WP Integration script: Update bundle for: $BRANCH_NAME"
 else
     ohai "There were no changes from bundle update to be committed."
 fi
@@ -155,15 +155,14 @@ PR Submission Checklist
 - [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
 execute "git" "push" "-u" "origin" "HEAD"
 
-# Create Draft GB-Mobile Release PR in GitHub
+# Create GB-Mobile PR in GitHub
 GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" \
 "--title" "App Integration for $GUTENBERG_MOBILE_BRANCH" \
 "--body" "$PR_BODY" \
 "--repo" "$MOBILE_REPO/gutenberg-mobile" \
 "--head" "$MOBILE_REPO:$GUTENBERG_MOBILE_BRANCH" \
 "--base" "$GUTENBERG_MOBILE_TARGET_BRANCH" \
-"--label" "$GUTENBERG_MOBILE_PR_LABEL" \
-"--draft")
+"--label" "$GUTENBERG_MOBILE_PR_LABEL" )
 
 cd gutenberg
 execute "git" "push" "-u" "origin" "HEAD"
@@ -181,7 +180,7 @@ WP_APPS_PR_TITLE="Integrate changes from gutenberg-mobile branch $GUTENBERG_MOBI
 WP_APPS_PR_BODY="## Description
 This PR incorporates the $GUTENBERG_MOBILE_BRANCH branch of gutenberg-mobile: $GB_MOBILE_PR_URL
 
-Release Submission Checklist
+Merge Submission Checklist
 
 - [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
 
@@ -218,8 +217,8 @@ execute "git" "commit" "-m" "Gutenberg ref update script: Update build.gradle gu
 ohai "Push integration branch"
 execute "git" "push" "-u" "origin" "HEAD"
 
-# Create Draft WPAndroid Release PR in GitHub
-ohai "Create Draft WPAndroid Release PR in GitHub"
+# Create Draft WPAndroid PR in GitHub
+ohai "Create Draft WPAndroid PR in GitHub"
 WP_ANDROID_PR_URL=$(execute "gh" "pr" "create" \
 "--title" "$WP_APPS_PR_TITLE" \
 "--body" "$WP_APPS_PR_BODY" --repo "$MOBILE_REPO/WordPress-Android" \
@@ -253,13 +252,13 @@ execute "rake" "dependencies"
 
 
 execute "git" "add" "Podfile" "Podfile.lock"
-execute "git" "commit" "-m" "Release script: Update gutenberg-mobile ref"
+execute "git" "commit" "-m" "WP Integration script: Update gutenberg-mobile ref"
 
 ohai "Push integration branch"
 execute "git" "push" "-u" "origin" "HEAD"
 
-# Create Draft WPiOS Release PR in GitHub
-ohai "Create Draft WPiOS Release PR in GitHub"
+# Create Draft WPiOS PR in GitHub
+ohai "Create Draft WPiOS PR in GitHub"
 WP_IOS_PR_URL=$(execute "gh" "pr" "create" \
 "--title" "$WP_APPS_PR_TITLE" \
 "--body" "$WP_APPS_PR_BODY" \

--- a/wp_gutenberg_ref_update_prs.sh
+++ b/wp_gutenberg_ref_update_prs.sh
@@ -83,6 +83,7 @@ fi
 # Ensure javascript dependencies are up-to-date
 read -r -p "Run 'npm ci' to ensure javascript dependencies are up-to-date? (y/n) " -n 1
 echo ""
+confirm_to_proceed "Script execution for creating WPApps PR's will take ~15-20 mins. Proceed? "
 if [[ $REPLY =~ ^[Yy]$ ]]; then
     execute "npm" "ci"
 fi

--- a/wp_gutenberg_ref_update_prs.sh
+++ b/wp_gutenberg_ref_update_prs.sh
@@ -58,10 +58,12 @@ confirm_to_proceed "Are you sure you want to create WPApps PRs from the gutenber
 # Confirm branch is clean
 [[ -z "$(git status --porcelain)" ]] || { git status; abort "Uncommitted changes found. Aborting release script..."; }
 
-# Ask for new version number
+# Ask for a branch name
 CURRENT_VERSION_NUMBER=$(jq '.version' package.json --raw-output)
+DEFAULT_GB_MOBILE_BRANCH_NAME="$CURRENT_VERSION_NUMBER-$CURRENT_BRANCH-${CURRENT_HASH:0:6}"
 echo "Current Version Number:$CURRENT_VERSION_NUMBER"
-read -r -p "Enter a name for your gb-mobile branch: " BRANCH_NAME
+read -r -p "Enter a name for your gb-mobile branch[$DEFAULT_GB_MOBILE_BRANCH_NAME]: " BRANCH_NAME
+BRANCH_NAME=${BRANCH_NAME:-"$DEFAULT_GB_MOBILE_BRANCH_NAME"}
 if [[ -z "$BRANCH_NAME" ]]; then
     abort "Version number cannot be empty."
 fi

--- a/wp_gutenberg_ref_update_prs.sh
+++ b/wp_gutenberg_ref_update_prs.sh
@@ -81,10 +81,10 @@ if [[ $REPLY =~ ^[Nn]$ ]]; then
 fi
 
 # Ensure javascript dependencies are up-to-date
-read -r -p "Run 'npm ci' to ensure javascript dependencies are up-to-date? (y/n) " -n 1
+read -r -p "Run 'npm ci' to ensure javascript dependencies are up-to-date? (y/n) " -n 1 PERFORM_NPM_CI
 echo ""
 confirm_to_proceed "Script execution for creating WPApps PR's will take ~15-20 mins. Proceed? "
-if [[ $REPLY =~ ^[Yy]$ ]]; then
+if [[ $PERFORM_NPM_CI =~ ^[Yy]$ ]]; then
     execute "npm" "ci"
 fi
 

--- a/wp_gutenberg_ref_update_prs.sh
+++ b/wp_gutenberg_ref_update_prs.sh
@@ -248,6 +248,7 @@ ohai "Update GitHub organization and gutenberg-mobile ref"
 test -f "Podfile" || abort "Error: Could not find Podfile"
 sed -i'.orig' -E "s/wordpress-mobile(\/gutenberg-mobile)/$MOBILE_REPO\1/" Podfile || abort "Error: Failed updating GitHub organization in Podfile"
 sed -i'.orig' -E "s/gutenberg :(commit|tag) => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
+execute "pod" "repo" "update"
 execute "rake" "dependencies"
 
 

--- a/wp_gutenberg_ref_update_prs.sh
+++ b/wp_gutenberg_ref_update_prs.sh
@@ -176,7 +176,7 @@ GB_MOBILE_PR_REF=$(git rev-parse HEAD)
 WP_APPS_PR_TITLE="Integrate changes from gutenberg-mobile branch $GUTENBERG_MOBILE_BRANCH"
 
 WP_APPS_PR_BODY="## Description
-This PR incorporates the $GUTENBERG_MOBILE_BRANCH branch of gutenberg-mobile.
+This PR incorporates the $GUTENBERG_MOBILE_BRANCH branch of gutenberg-mobile: $GB_MOBILE_PR_URL
 
 Release Submission Checklist
 

--- a/wp_gutenberg_ref_update_prs.sh
+++ b/wp_gutenberg_ref_update_prs.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+
+# INSTRUCTIONS FOR TESTING FROM FORKED REPOS
+# Prerequisites:
+# 1. Fork the following repos to your github user repo:
+#    a) Gutenberg-Mobile: https://github.com/wordpress-mobile/gutenberg-mobile
+#    * .gitmodules on CURRENT_BRANCH should reference your gutenberg fork, replace 'WordPress' with GITHUB_USERNAME
+#    * (https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/.gitmodules)
+#    b) Gutenberg: https://github.com/WordPress/gutenberg
+#    c) WordPress-Android: https://github.com/wordpress-mobile/WordPress-Android
+#    d) WordPress-iOS: https://github.com/wordpress-mobile/WordPress-iOS
+# 2. Insure that each of your forked repos contains the PR labels specified below:
+GUTENBERG_MOBILE_PR_LABEL="release-process"
+WPANDROID_PR_LABEL="gutenberg-mobile"
+WPIOS_PR_LABEL="Gutenberg integration"
+# 3. Ensure that each of your repos contains the target branch listed below:
+GUTENBERG_MOBILE_TARGET_BRANCH="trunk"
+WPANDROID_TARGET_BRANCH="develop"
+WPIOS_TARGET_BRANCH="develop"
+# 4. Update the repo names below to the user repo name for your fork
+ MOBILE_REPO="wordpress-mobile"
+# MOBILE_REPO="YOUR_GITHUB_USERNAME"
+# 5. Clone the forked gutenberg-mobile repo
+
+set -e
+
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Ask for path to gutenberg-mobile directory
+# (default is sibling directory of gutenberg-mobile-release-toolkit)
+DEFAULT_GB_MOBILE_LOCATION="$SCRIPT_PATH/../gutenberg-mobile"
+
+read -r -p "Please enter the path to the gutenberg-mobile directory [$DEFAULT_GB_MOBILE_LOCATION]:" GB_MOBILE_PATH
+GB_MOBILE_PATH=${GB_MOBILE_PATH:-"$DEFAULT_GB_MOBILE_LOCATION"}
+echo ""
+if [[ ! "$GB_MOBILE_PATH" == *gutenberg-mobile ]]; then
+    abort "Error path does not end with gutenberg-mobile"
+fi
+
+source ./release_utils.sh
+
+# Execute script commands from gutenberg-mobile directory
+cd "$GB_MOBILE_PATH"
+
+# Check that Github CLI is installed
+command -v gh >/dev/null || abort "Error: The Github CLI must be installed."
+
+# Check that Github CLI is logged
+gh auth status >/dev/null 2>&1 || abort "Error: You are not logged into any GitHub hosts. Run 'gh auth login' to authenticate."
+
+# Check that jq is installed
+command -v jq >/dev/null || abort "Error: jq must be installed."
+
+## Check current branch is develop, trunk, or release/* branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+CURRENT_HASH=$(git rev-parse HEAD)
+confirm_to_proceed "Are you sure you want to create WPApps PRs from the gutenberg-mobile '$CURRENT_BRANCH' branch, commit: $CURRENT_HASH ?"
+
+# Confirm branch is clean
+[[ -z "$(git status --porcelain)" ]] || { git status; abort "Uncommitted changes found. Aborting release script..."; }
+
+# Ask for new version number
+CURRENT_VERSION_NUMBER=$(jq '.version' package.json --raw-output)
+echo "Current Version Number:$CURRENT_VERSION_NUMBER"
+read -r -p "Enter a name for your gb-mobile branch: " BRANCH_NAME
+if [[ -z "$BRANCH_NAME" ]]; then
+    abort "Version number cannot be empty."
+fi
+
+# Ask for WPAndroid target branch
+read -r -p "Do you want to target $WPANDROID_TARGET_BRANCH branch for WPAndroid PR? (y/n) " -n 1
+echo ""
+if [[ $REPLY =~ ^[Nn]$ ]]; then
+    read -r -p "Enter the branch name you want to target. Make sure a branch with this name already exists in WPAndroid repository: " WPANDROID_TARGET_BRANCH
+fi
+
+# Ask for WPiOS target branch
+read -r -p "Do you want to target $WPIOS_TARGET_BRANCH branch for WPiOS PR? (y/n) " -n 1
+echo ""
+if [[ $REPLY =~ ^[Nn]$ ]]; then
+    read -r -p "Enter the branch name you want to target. Make sure a branch with this name already exists in WPiOS repository: " WPIOS_TARGET_BRANCH
+fi
+
+# Ensure javascript dependencies are up-to-date
+read -r -p "Run 'npm ci' to ensure javascript dependencies are up-to-date? (y/n) " -n 1
+echo ""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    execute "npm" "ci"
+fi
+
+# Create Git branch
+GUTENBERG_MOBILE_BRANCH="$BRANCH_NAME"
+ohai "Create Git branch '$GUTENBERG_MOBILE_BRANCH' in gutenberg-mobile."
+execute "git" "switch" "-c" "$GUTENBERG_MOBILE_BRANCH"
+
+# Create Git branch in Gutenberg
+GB_BRANCH="rnmobile/$GUTENBERG_MOBILE_BRANCH"
+ohai "Create Git branch '$GB_BRANCH' in gutenberg."
+cd gutenberg
+execute "git" "switch" "-c" "$GB_BRANCH"
+cd ..
+
+# Make sure podfile is updated
+ohai "Make sure podfile is updated"
+PRE_IOS_COMMAND="npm run core preios"
+eval "$PRE_IOS_COMMAND"
+
+# If preios results in changes, commit them
+cd gutenberg
+if [[ -n "$(git status --porcelain)" ]]; then
+    ohai "Commit changes from '$PRE_IOS_COMMAND'"
+    execute "git" "commit" "-a" "-m" "Release script: Update with changes from '$PRE_IOS_COMMAND'"
+else
+    ohai "There were no changes from '$PRE_IOS_COMMAND' to be committed."
+fi
+cd ..
+
+# Commit updates to gutenberg submodule
+if [[ -n "$(git status --porcelain)" ]]; then
+    ohai "Commit updates to gutenberg submodule"
+    execute "git" "add" "gutenberg"
+    execute "git" "commit" "-m" "Release script: Update gutenberg ref"
+else
+    ohai "There were no changes from submodule update to be committed."
+fi
+
+# Update the bundles
+ohai "Update the bundles"
+npm run bundle || abort "Error: 'npm bundle' failed.\nIf there is an error stating something like \"Command 'bundle' unrecognized.\" above, perhaps try running 'rm -rf node_modules gutenberg/node_modules && npm ci'."
+
+# Commit bundle changes
+if [[ -n "$(git status --porcelain)" ]]; then
+    ohai "Commit bundle changes"
+    execute "git" "add" "bundle/"
+    execute "git" "commit" "-m" "Release script: Update bundle for: $BRANCH_NAME"
+else
+    ohai "There were no changes from bundle update to be committed."
+fi
+
+
+#####
+# Create PRs
+#####
+
+# Replace version number in GB-Mobile PR template
+PR_BODY="## Description
+This PR is for publishing the $GUTENBERG_MOBILE_BRANCH branch of gutenberg-mobile to S3 for testing in WPApps repos.
+
+
+
+PR Submission Checklist
+- [ ] Update target branch away from trunk unless this is a release PR
+- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
+execute "git" "push" "-u" "origin" "HEAD"
+
+# Create Draft GB-Mobile Release PR in GitHub
+GB_MOBILE_PR_URL=$(execute "gh" "pr" "create" \
+"--title" "App Integration for $GUTENBERG_MOBILE_BRANCH" \
+"--body" "$PR_BODY" \
+"--repo" "$MOBILE_REPO/gutenberg-mobile" \
+"--head" "$MOBILE_REPO:$GUTENBERG_MOBILE_BRANCH" \
+"--base" "$GUTENBERG_MOBILE_TARGET_BRANCH" \
+"--label" "$GUTENBERG_MOBILE_PR_LABEL" \
+"--draft")
+
+cd gutenberg
+execute "git" "push" "-u" "origin" "HEAD"
+cd ..
+
+echo "Branches pushed to remote"
+echo "==========="
+
+ohai "Proceeding to create main apps PRs..."
+
+GB_MOBILE_PR_REF=$(git rev-parse HEAD)
+
+WP_APPS_PR_TITLE="Integrate changes from gutenberg-mobile branch $GUTENBERG_MOBILE_BRANCH"
+
+WP_APPS_PR_BODY="## Description
+This PR incorporates the $GUTENBERG_MOBILE_BRANCH branch of gutenberg-mobile.
+
+Release Submission Checklist
+
+- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary."
+
+WP_APPS_INTEGRATION_BRANCH="gutenberg/integrate_$GUTENBERG_MOBILE_BRANCH"
+
+
+#####
+# WPAndroid PR
+#####
+
+TEMP_WP_ANDROID_DIRECTORY=$(mktemp -d)
+ohai "Clone WordPress-Android into '$TEMP_WP_ANDROID_DIRECTORY'"
+execute "git" "clone" "-b" "$WPANDROID_TARGET_BRANCH" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-Android.git" "$TEMP_WP_ANDROID_DIRECTORY"
+
+cd "$TEMP_WP_ANDROID_DIRECTORY"
+
+# This is still needed because of Android Stories.
+execute "git" "submodule" "update" "--init" "--recursive" "--depth=1" "--recommend-shallow"
+
+
+ohai "Create integration branch in WordPress-Android"
+execute "git" "switch" "-c" "$WP_APPS_INTEGRATION_BRANCH"
+
+# Get the last part of the path from GB_MOBILE_PR_URL
+PULL_ID=${GB_MOBILE_PR_URL##*/}
+
+ohai "Update build.gradle file with the latest version"
+test -f "build.gradle" || abort "Error: Could not find build.gradle"
+sed -i'.orig' -E "s/ext.gutenbergMobileVersion = '(.*)'/ext.gutenbergMobileVersion = '${PULL_ID}-$GB_MOBILE_PR_REF'/" build.gradle || abort "Error: Failed updating gutenbergMobileVersion in build.gradle"
+
+execute "git" "add" "build.gradle"
+execute "git" "commit" "-m" "Gutenberg ref update script: Update build.gradle gutenbergMobileVersion to ref"
+
+ohai "Push integration branch"
+execute "git" "push" "-u" "origin" "HEAD"
+
+# Create Draft WPAndroid Release PR in GitHub
+ohai "Create Draft WPAndroid Release PR in GitHub"
+WP_ANDROID_PR_URL=$(execute "gh" "pr" "create" \
+"--title" "$WP_APPS_PR_TITLE" \
+"--body" "$WP_APPS_PR_BODY" --repo "$MOBILE_REPO/WordPress-Android" \
+"--head" "$MOBILE_REPO:$WP_APPS_INTEGRATION_BRANCH" \
+"--base" "$WPANDROID_TARGET_BRANCH" \
+"--label" "$WPANDROID_PR_LABEL" \
+"--draft")
+
+ohai "WPAndroid PR Created: $WP_ANDROID_PR_URL"
+echo ""
+
+
+#####
+# WPiOS PR
+#####
+
+TEMP_WP_IOS_DIRECTORY=$(mktemp -d)
+ohai "Clone WordPress-iOS into '$TEMP_WP_IOS_DIRECTORY'"
+execute "git" "clone" "-b" "$WPIOS_TARGET_BRANCH" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-iOS.git" "$TEMP_WP_IOS_DIRECTORY"
+
+cd "$TEMP_WP_IOS_DIRECTORY"
+
+ohai "Create integration branch in WordPress-iOS"
+execute "git" "switch" "-c" "$WP_APPS_INTEGRATION_BRANCH"
+
+ohai "Update GitHub organization and gutenberg-mobile ref"
+test -f "Podfile" || abort "Error: Could not find Podfile"
+sed -i'.orig' -E "s/wordpress-mobile(\/gutenberg-mobile)/$MOBILE_REPO\1/" Podfile || abort "Error: Failed updating GitHub organization in Podfile"
+sed -i'.orig' -E "s/gutenberg :(commit|tag) => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
+execute "rake" "dependencies"
+
+
+execute "git" "add" "Podfile" "Podfile.lock"
+execute "git" "commit" "-m" "Release script: Update gutenberg-mobile ref"
+
+ohai "Push integration branch"
+execute "git" "push" "-u" "origin" "HEAD"
+
+# Create Draft WPiOS Release PR in GitHub
+ohai "Create Draft WPiOS Release PR in GitHub"
+WP_IOS_PR_URL=$(execute "gh" "pr" "create" \
+"--title" "$WP_APPS_PR_TITLE" \
+"--body" "$WP_APPS_PR_BODY" \
+"--repo" "$MOBILE_REPO/WordPress-iOS" \
+"--head" "$MOBILE_REPO:$WP_APPS_INTEGRATION_BRANCH" \
+"--base" "$WPIOS_TARGET_BRANCH" \
+"--label" "$WPIOS_PR_LABEL" \
+"--draft")
+
+ohai "WPiOS PR Created: $WP_IOS_PR_URL"
+echo ""
+echo "GB-Mobile PR and branch info:"
+echo "==========="
+
+printf "Gutenberg-Mobile PR %s \n Gutenberg Branch %s \n" "$GB_MOBILE_PR_URL" "$GB_BRANCH" | column -t
+echo ""
+echo "Main apps PRs created"
+echo "==========="
+printf "WPAndroid %s \n WPiOS %s \n" "$WP_ANDROID_PR_URL" "$WP_IOS_PR_URL" | column -t
+echo ""
+echo "Please don't forget to delete test branches / PRs when finished. Thank you!"


### PR DESCRIPTION
## Summary:

The `./wp_gutenberg_ref_update_prs.sh` script can be used for automatically generating Pull Requests in the [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android)and [WordPress-iOS](https://github.com/wordpress-mobile/WordPress-iOS) GitHub repositories that integrate changes from a specific [gutenberg-mobile](https://github.com/wordpress-mobile/gutenberg-mobile) branch.

## Testing
You can test this on a fork by setting `MOBILE_REPO="YOUR_GITHUB_USERNAME"` and following the rest of the instructions at the top of `./wp_gutenberg_ref_update_prs.sh`