### PR TITLE
Removed Bintray reference from the release checklist

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -56,7 +56,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Verify the WPAndroid PR build succeeds. If PR CI tasks include a 403 error related to an inability to resolve the <code>react-native-bridge</code> dependency, you must wait until the <code>Build Android RN Bridge & Publish to Bintray</code> task completes in <code>gutenberg-mobile</code> and then restart the WPAndroid CI tasks.</p>
+<p>o Verify the WPAndroid PR build succeeds. If PR CI tasks include a 403 error related to an inability to resolve the <code>react-native-bridge</code> dependency, you must wait until the <code>Build Android RN Bridge & Publish to S3</code> task completes in <code>gutenberg-mobile</code> and then restart the WPAndroid CI tasks.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
This PR simply updates a reference from Bintray to S3 to avoid any confusion. 