### PR TITLE
Split the release notes/changelog check entry

### DIFF
--- a/release_pull_request.md
+++ b/release_pull_request.md
@@ -31,5 +31,6 @@ No extra PRs yet. 🎉
 
 - [ ] Verify Items from test plan have been completed
 - [ ] Approve and run optional Android and iOS UI tests
-- [ ] Check if `RELEASE-NOTES.txt` and `gutenberg/packages/react-native-editor/CHANGELOG.md` are updated with all the changes that made it to the release.
+- [ ] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release.
+- [ ] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release.
 - [ ] Bundle package of the release is updated.


### PR DESCRIPTION
The purpose of splitting the entry related to checking if release notes and changelog files are updated is to make it clearer that both files have to be reviewed.