### PR TITLE
Add extra steps to guarantee that the Pods repository is always up-to-date

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -343,7 +343,6 @@ ohai "Update GitHub organization and gutenberg-mobile ref"
 test -f "Podfile" || abort "Error: Could not find Podfile"
 sed -i'.orig' -E "s/wordpress-mobile(\/gutenberg-mobile)/$MOBILE_REPO\1/" Podfile || abort "Error: Failed updating GitHub organization in Podfile"
 sed -i'.orig' -E "s/gutenberg :(commit|tag) => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
-execute "bundle" "install"
 execute "bundle" "exec" "pod" "repo" "update"
 execute "rake" "dependencies"
 

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -289,6 +289,7 @@ ohai "Update GitHub organization and gutenberg-mobile ref"
 test -f "Podfile" || abort "Error: Could not find Podfile"
 sed -i'.orig' -E "s/wordpress-mobile(\/gutenberg-mobile)/$MOBILE_REPO\1/" Podfile || abort "Error: Failed updating GitHub organization in Podfile"
 sed -i'.orig' -E "s/gutenberg :(commit|tag) => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
+execute "bundle" "install"
 execute "bundle" "exec" "pod" "repo" "update"
 execute "rake" "dependencies"
 

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -343,8 +343,9 @@ ohai "Update GitHub organization and gutenberg-mobile ref"
 test -f "Podfile" || abort "Error: Could not find Podfile"
 sed -i'.orig' -E "s/wordpress-mobile(\/gutenberg-mobile)/$MOBILE_REPO\1/" Podfile || abort "Error: Failed updating GitHub organization in Podfile"
 sed -i'.orig' -E "s/gutenberg :(commit|tag) => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
+execute "bundle" "install"
+execute "bundle" "exec" "pod" "repo" "update"
 execute "rake" "dependencies"
-
 
 execute "git" "add" "Podfile" "Podfile.lock"
 execute "git" "commit" "-m" "Release script: Update gutenberg-mobile ref"


### PR DESCRIPTION
This PR adds the following steps to the WordPress iOS PR section:
1. `bundle install`: Installs Ruby dependencies, this is step is required to have the Cocoapods gem up-to-date with the `Gemfile`.
2. `bundle exec pod repo update`: Updates the Pods repository, this will help us to prevent potential errors when installing Pods that have been upgraded recently.