### PR TITLE
Update Release prechecks

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -92,7 +92,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Verify the localization strings files (<a href="https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bundle/android/strings.xml">bundle/android/strings.xml</a>, <a href="https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bundle/ios/GutenbergNativeTranslations.swift">bundle/ios/GutenbergNativeTranslations.swift</a>) have been generated properly. Check that we're not adding extra strings from non-native files and that we're not removing strings that are referenced in the code (more info can be found in this <a href="https://github.com/wordpress-mobile/gutenberg-mobile/issues/3466">issue</a>). <strong>If any issue is found, it will require manually modifying the files and push them to the release branch.</strong></p>
+<p>o Verify the localization strings files (<a href="https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bundle/android/strings.xml">bundle/android/strings.xml</a>, <a href="https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bundle/ios/GutenbergNativeTranslations.swift">bundle/ios/GutenbergNativeTranslations.swift</a>) have been generated properly. Check that we're not adding extra strings from non-native files and that we're not removing strings that are referenced in the code (more info can be found in this <a href="https://github.com/wordpress-mobile/gutenberg-mobile/issues/3466">issue</a>). <strong>If any issue is found, it will require manually modifying the files and push them to the release branch.</strong> If no strings are updated, it is expected to not see those files modified.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/release_prechecks.sh
+++ b/release_prechecks.sh
@@ -52,18 +52,6 @@ function check_ios_aztec_is_release_version() {
         result="A release version for WordPress-Aztec-iOS was not found in $podspec_file"
     fi
 
-    podfile="$GB_MOBILE_PATH/gutenberg/packages/react-native-editor/ios/Podfile"
-    commented_out_reference_in_podfile=$(grep -E "# *pod 'WordPress-Aztec-iOS'" "$podfile")
-    if [[ -z "$commented_out_reference_in_podfile" ]]; then
-        message="The developer version of WordPress-Aztec-iOS was not commented out in $podfile"
-        if [[ -z "$result" ]]; then
-            result="$message"
-        else
-            result="${result}\n${message}"
-        fi
-
-    fi
-
     echo "$result"
 }
 


### PR DESCRIPTION
After upgrading to React Native `0.64` [linking pods are done automatically](https://github.com/WordPress/gutenberg/commit/b4623e3a83ef801f2de3071172fe92ae89305210#diff-9a2250a2cc0b1edbfbdf9cd4edc78323b6bccd9cf02689be56a6b7b90d065d26) so this precheck to avoid including a developer version of `WordPress-Aztec-iOS` is not needed. So I propose to remove this check which currently fails since its not a use case anymore.

I also added a subcase for the `Verify the localization strings files` step of the release checklist.