### PR TITLE
Tweak order of steps under "Create the Release" checklist

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -94,6 +94,10 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- wp:paragraph -->
 <p>o Verify the localization strings files (<a href="https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bundle/android/strings.xml">bundle/android/strings.xml</a>, <a href="https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bundle/ios/GutenbergNativeTranslations.swift">bundle/ios/GutenbergNativeTranslations.swift</a>) have been generated properly. Check that we're not adding extra strings from non-native files and that we're not removing strings that are referenced in the code (more info can be found in this <a href="https://github.com/wordpress-mobile/gutenberg-mobile/issues/3466">issue</a>). <strong>If any issue is found, it will require manually modifying the files and push them to the release branch.</strong> If no strings are updated, it is expected to not see those files modified.</p>
 <!-- /wp:paragraph -->
+  
+<!-- wp:paragraph -->
+<p>o In both <code>RELEASE-NOTES.txt</code> and <code>gutenberg/packages/react-native-editor/CHANGELOG.md</code>, replace <code>Unreleased</code> section with the release version and create a new <code>Unreleased</code> section.</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>o Run the Optional Tests on both the WPiOS and WPAndroid PRs.</p>
@@ -109,10 +113,6 @@ For the body of the post, just copy this checklist and again replace all occurre
 
 <!-- wp:paragraph -->
 <p>o Fill in the missing parts of the gutenberg-mobile PR description.</p>
-<!-- /wp:paragraph -->
-  
-<!-- wp:paragraph -->
-<p>o In both <code>RELEASE-NOTES.txt</code> and <code>gutenberg/packages/react-native-editor/CHANGELOG.md</code>, replace <code>Unreleased</code> section with the release version and create a new <code>Unreleased</code> section.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/Releasing.md
+++ b/Releasing.md
@@ -88,10 +88,6 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:group -->
 
 <!-- wp:paragraph -->
-<p>o Verify the WPAndroid PR build succeeds. If PR CI tasks include a 403 error related to an inability to resolve the <code>react-native-bridge</code> dependency, you must wait for the <code>Build Android RN Bridge &amp; Publish to S3</code> task to succeed in gutenberg-mobile and then restart the WPAndroid CI tasks.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
 <p>o Verify the localization strings files (<a href="https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bundle/android/strings.xml">bundle/android/strings.xml</a>, <a href="https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/bundle/ios/GutenbergNativeTranslations.swift">bundle/ios/GutenbergNativeTranslations.swift</a>) have been generated properly. Check that we're not adding extra strings from non-native files and that we're not removing strings that are referenced in the code (more info can be found in this <a href="https://github.com/wordpress-mobile/gutenberg-mobile/issues/3466">issue</a>). <strong>If any issue is found, it will require manually modifying the files and push them to the release branch.</strong> If no strings are updated, it is expected to not see those files modified.</p>
 <!-- /wp:paragraph -->
   
@@ -99,6 +95,10 @@ For the body of the post, just copy this checklist and again replace all occurre
 <p>o In both <code>RELEASE-NOTES.txt</code> and <code>gutenberg/packages/react-native-editor/CHANGELOG.md</code>, replace <code>Unreleased</code> section with the release version and create a new <code>Unreleased</code> section.</p>
 <!-- /wp:paragraph -->
 
+<!-- wp:paragraph -->
+<p>o Verify the WPAndroid PR build succeeds. If PR CI tasks include a 403 error related to an inability to resolve the <code>react-native-bridge</code> dependency, you must wait for the <code>Build Android RN Bridge &amp; Publish to S3</code> task to succeed in gutenberg-mobile and then restart the WPAndroid CI tasks.</p>
+<!-- /wp:paragraph -->  
+  
 <!-- wp:paragraph -->
 <p>o Run the Optional Tests on both the WPiOS and WPAndroid PRs.</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
This PR suggests a tweak to the order of steps listed under the "Create the Release" section of the release checklist.

The release notes need to be updated in both the Gutenberg and Gutenberg Mobile repositories before the PRs are ready for review. As these updates require new commits, it'll be necessary to wait for each PRs' tests to finish after they're made. It'd therefore be most efficient to make any updates to the release notes _before_ steps like running optional tests or triggering a build. 

As such, this PR suggests moving all test-related steps after the updates to the release notes have been made.