### PR TITLE
Run bundle install before installing iOS dependencies

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -289,6 +289,7 @@ ohai "Update GitHub organization and gutenberg-mobile ref"
 test -f "Podfile" || abort "Error: Could not find Podfile"
 sed -i'.orig' -E "s/wordpress-mobile(\/gutenberg-mobile)/$MOBILE_REPO\1/" Podfile || abort "Error: Failed updating GitHub organization in Podfile"
 sed -i'.orig' -E "s/gutenberg :(commit|tag) => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
+execute "bundle" "install"
 execute "rake" "dependencies"
 
 


### PR DESCRIPTION
I bumped into the following error when executing the release script for betafix 1.58.1:

```
==> Create release branch in WordPress-iOS
Switched to a new branch 'gutenberg/integrate_release_1.58.1'
==> Update GitHub organization and gutenberg-mobile ref
Warning: the running version of Bundler (2.2.10) is older than the version that created the lockfile (2.2.21). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.21`.
Could not find proper version of rake (12.3.3) in any of the sources
Run `bundle install` to install missing gems.

Failed during: rake dependencies
```

Looks like we need to assure that the Ruby dependencies are up-to-date before running `rake dependencies`.