### PR TITLE
Update Release Checklist to Clarify Best Practices When Editing Release PR

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -112,7 +112,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Fill in the missing parts of the gutenberg-mobile PR description.</p>
+<p>o Fill in the missing parts of the gutenberg-mobile PR description. When filling in the "Changes" section, link to the most descriptive GitHub issue for any given change and consider adding a short description. Testers rely on this section to gather more details about changes in a release.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/release_pull_request.md
+++ b/release_pull_request.md
@@ -17,8 +17,13 @@ No extra PRs yet. 🎉
 
 <!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->
 
-- Change 1: link-to-pr-describing-change-1
-- Change 2: link-to-pr-describing-change-2
+### Change 1
+- **PR:** link-to-pr-related-to-change-1
+- **Issue:** link-to-issue-related-to-change-1
+
+### Change 2
+- **PR:** link-to-pr-related-to-change-2
+- **Issue:** link-to-issue-related-to-change-2
 
 ## Test plan
 


### PR DESCRIPTION
During a discussion that @startuptester started at p5T066-2wE-p2#comment-9434, it became clear that it can be tricky for those testing a gutenberg-mobile release to easily pinpoint changes and testing steps.

Part of the issue here is the number of PRs that need to be wrangled as part of the release, but it's also clear that the GitHub issues we link to sometimes don't contain a description of the changes and instead link to different issues themselves. Testers sometimes need to spend time clicking through multiple issues to get to the details they need.

With this PR, some extra text has been added to the release wrangling checklist to encourage release wranglers to keep testers in mind when filling out the release PR. The hope is to remind release wranglers to link directly to whichever GitHub issue actually contains the change's description/testing steps and also for them to consider adding a brief description.

### Task's text before:

> Fill in the missing parts of the gutenberg-mobile PR description

### Task's text after:

> Fill in the missing parts of the gutenberg-mobile PR description. When filling in the "Changes" section, link to the most descriptive GitHub issue for any given change and consider adding a short description. Testers rely on this section to gather more details about changes in a release.

Open to any ideas for further tweaking the text!