### PR TITLE
Clarify day of week regular releases are performed

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -312,7 +312,7 @@ It's best practice to use the automation script (mentioned in the release templa
 
 ### When
 
-On Fridays, the week before the main apps (WPiOS & WPAndroid) have cut their releases, every 2 weeks.
+On Thursdays, the week before the main apps (WPiOS & WPAndroid) have cut their releases, every 2 weeks.
 
 ### Branches
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -312,7 +312,7 @@ It's best practice to use the automation script (mentioned in the release templa
 
 ### When
 
-On Mondays, one week before main apps (WPiOS & WPAndroid) have cut their releases, every 2 weeks.
+On Fridays, the week before the main apps (WPiOS & WPAndroid) have cut their releases, every 2 weeks.
 
 ### Branches
 


### PR DESCRIPTION
It's my understanding we've been cutting Gutenberg Mobile releases on the Friday (or Thursday) before the main apps cut their release. Previously, we'd cut the Gutenberg Mobile release earlier, on the Monday of the week prior to the main apps cutting their release. 

This just updates the docs to make that clear.