### PR TITLE
Update the local CocoaPods spec repo

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -66,6 +66,11 @@ gh auth status >/dev/null 2>&1 || abort "Error: You are not logged into any GitH
 # Check that jq is installed
 command -v jq >/dev/null || abort "Error: jq must be installed."
 
+# Updating the local spec repos benefits both Gutenberg and WPiOS which use CocoaPods
+# This avoids the scenario where the script aborts due to a 'CocoaPods could not find compatible versions for pod' error.
+ohai "Update the spec repos located at ~/.cocoapods/repos"
+execute "pod" "repo" "update"
+
 # Check that Aztec versions are set to release versions
 aztec_version_problems="$(check_android_and_ios_aztec_versions)"
 if [[ -n "$aztec_version_problems" ]]; then
@@ -270,9 +275,6 @@ echo ""
 if [[ $REPLY =~ ^[Nn]$ ]]; then
     read -r -p "Enter the branch name you want to target. Make sure a branch with this name already exists in WPiOS repository: " WPIOS_TARGET_BRANCH
 fi
-
-ohai "Update the spec repos located at ~/.cocoapods/repos"
-execute "pod" "repo" "update"
 
 TEMP_WP_IOS_DIRECTORY=$(mktemp -d)
 ohai "Clone WordPress-iOS into '$TEMP_WP_IOS_DIRECTORY'"

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -271,6 +271,9 @@ if [[ $REPLY =~ ^[Nn]$ ]]; then
     read -r -p "Enter the branch name you want to target. Make sure a branch with this name already exists in WPiOS repository: " WPIOS_TARGET_BRANCH
 fi
 
+ohai "Update the spec repos located at ~/.cocoapods/repos"
+execute "pod" "repo" "update"
+
 TEMP_WP_IOS_DIRECTORY=$(mktemp -d)
 ohai "Clone WordPress-iOS into '$TEMP_WP_IOS_DIRECTORY'"
 execute "git" "clone" "-b" "$WPIOS_TARGET_BRANCH" "--depth=1" "git@github.com:$MOBILE_REPO/WordPress-iOS.git" "$TEMP_WP_IOS_DIRECTORY"


### PR DESCRIPTION
Updating the local CocoaPods spec repo helps ensure the release script doesn't fail with a `CocoaPods could not find compatible versions for pod` error.
This error is caused by stale local spec repos and can be fixed with `pod repo update`, so this has been added to the script.