### PR TITLE
Correct step syntax so that all content is shown

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -74,7 +74,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Review the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/develop/Releasing.md">release script instructions</a>. In your clone of the release scripts, run the script via:  <code>./release_automation.sh</code>. This creates the gutenberg and gutenberg-mobile release PRs as well as WPAndroid and WPiOS integration PRs.</p>. Note: You might want to wait a bit before confirming WPAndroid PR creation so gutenberg-mobile can have enough time to finish the <code>Build Android RN Bridge &amp; Publish to S3</code> job on CI which is needed by WPAndroid CI.
+<p>o Review the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/develop/Releasing.md">release script instructions</a>. In your clone of the release scripts, run the script via:  <code>./release_automation.sh</code>. This creates the gutenberg and gutenberg-mobile release PRs as well as WPAndroid and WPiOS integration PRs.<br><br><strong>Note:</strong> You might want to wait a bit before confirming WPAndroid PR creation so gutenberg-mobile can have enough time to finish the <code>Build Android RN Bridge &amp; Publish to S3</code> job on CI which is needed by WPAndroid CI.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:group -->


### PR DESCRIPTION
The step:

```
Review the release script instructions...
```

currently contains broken syntax that shows an error in Gutenberg.

This PR corrects the syntax so that all of the content is shown and no error appears.

<div>
<img width="300" alt="Before screenshot showing the error and missing content" src="https://user-images.githubusercontent.com/2092798/135908354-b298d653-3a07-4a9f-9bfe-a8d929232b98.png">
<img width="300" alt="After screenshot showing the error fixed" src="https://user-images.githubusercontent.com/2092798/135908411-bc1067c1-bb46-4a18-8050-db5ebb8bd270.png">
</div>
