### PR TITLE
Release Checklist: Clarify Message to Send When Releasing a Beta

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -196,7 +196,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph -->
-<p>o Once everything is merged, send a heads up to our friends in the <code>#platform9</code> Slack channel. If the release is for the frozen WPiOS and WPAndroid release branches (i.e. this is a beta/hot fix, e.g. X.XX.2), the message will look similar to the following:</p>
+<p>o Once everything is merged, send a heads up to our friends in the <code>#platform9</code> Slack channel. If the release is for the frozen WPiOS and WPAndroid release branches (i.e. this isn't a beta/hot fix, e.g. X.XX.2), the message will look similar to the following:</p>
 <!-- /wp:paragraph -->  
   
 <!-- wp:quote -->

--- a/Releasing.md
+++ b/Releasing.md
@@ -196,11 +196,19 @@ For the body of the post, just copy this checklist and again replace all occurre
 
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph -->
-<p>o Once everything is merged, send a message similar to the following to our friends in the <code>#platform9</code> Slack channel. If the release is a beta/hot fix (e.g. X.XX.2), be sure to directly mention the relevant Excellence Wranglers for the release and modify the following template as needed.</p>
-<!-- /wp:paragraph -->
-
+<p>o Once everything is merged, send a heads up to our friends in the <code>#platform9</code> Slack channel. If the release is for the frozen WPiOS and WPAndroid release branches (i.e. this is a beta/hot fix, e.g. X.XX.2), the message will look similar to the following:</p>
+<!-- /wp:paragraph -->  
+  
 <!-- wp:quote -->
 <blockquote class="wp-block-quote"><p>Hey team. I wanted to let you know that the mobile Gutenberg team has finished integrating the X.XX.X Gutenberg release into the WPiOS and WPAndroid `develop` branches. The integration is ready for the next release cut/build creation when you are available. Please let me know if you have any questions. Thanks! </p></blockquote>
+<!-- /wp:quote -->
+  
+<!-- wp:paragraph -->
+<p>o If the release is a beta/hot fix (e.g. X.XX.2), be sure to directly mention the relevant Excellence Wranglers for the release and modify the following template, similar to the following:</p>
+<!-- /wp:paragraph -->  
+  
+<!-- wp:quote -->
+<blockquote class="wp-block-quote"><p>Hey team. I wanted to let you know that the mobile Gutenberg team has finished integrating the X.XX.X Gutenberg release into the WPiOS and WPAndroid `release/XX.X` branches, ready for a new beta when you are available. Please let me know if you have any questions. Thanks! </p></blockquote>
 <!-- /wp:quote --></div>
 <!-- /wp:group -->
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -196,7 +196,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 
 <!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph -->
-<p>o Once everything is merged, send a heads up to our friends in the <code>#platform9</code> Slack channel. If the release is for the frozen WPiOS and WPAndroid release branches (i.e. this isn't a beta/hot fix, e.g. X.XX.2), the message will look similar to the following:</p>
+<p>o Once everything is merged, send a heads up to our friends in the <code>#platform9</code> Slack channel. If this is a "regular" release for the WPiOS and WPAndroid `develop` branches (i.e. this isn't a beta/hot fix, e.g. X.XX.2), the message will look similar to the following:</p>
 <!-- /wp:paragraph -->  
   
 <!-- wp:quote -->


### PR DESCRIPTION
### Description

After finishing a release, the following step in the release checklist prompts us to send a message to Platform:

```
o Once everything is merged, send a message similar to the following to our friends in the #platform9 Slack channel. If the release is a beta/hot fix (e.g. X.XX.2), be sure to directly mention the relevant Excellence Wranglers for the release and modify the following template as needed.

> Hey team. I wanted to let you know that the mobile Gutenberg team has finished integrating the 1.56.0 Gutenberg release into the WPiOS and WPAndroid `develop` branches. The integration is ready for the next release cut/build creation when you are available. Please let me know if you have any questions. Thanks!
```

Although the step prompts us to tweak the template for beta releases, it can be easy to skim past and go straight to copy/paste the available template. 

I made the mistake of not tweaking the template recently and it was mentioned in p1634126691188300/1634125485.187300-slack-CC7L49W13 that I'm not the only one, with a suggestion for updating our checklist.

### Proposal

To reduce the risk of human error when copying/pasting the message for Platform, this PR suggests adding a clarifying step with a second template that can be copied/pasted for beta releases:

```
o Once everything is merged, send a heads up to our friends in the #platform9 Slack channel. If the release is for the frozen WPiOS and WPAndroid release branches (i.e. this isn't a beta/hot fix, e.g. X.XX.2), the message will look similar to the following:
  
> Hey team. I wanted to let you know that the mobile Gutenberg team has finished integrating the X.XX.X Gutenberg release into the WPiOS and WPAndroid `develop` branches. The integration is ready for the next release cut/build creation when you are available. Please let me know if you have any questions. Thanks! 

o If the release is a beta/hot fix (e.g. X.XX.2), be sure to directly mention the relevant Excellence Wranglers for the release and modify the following template, similar to the following:

> Hey team. I wanted to let you know that the mobile Gutenberg team has finished integrating the X.XX.X Gutenberg release into the WPiOS and WPAndroid `release/XX.X` branches, ready for a new beta when you are available. Please let me know if you have any questions. Thanks! 
```

By adding this clarifying step, it's hoped that the opportunity for human error will be reduced and that a clear message will always be sent to Platform when releasing a beta.