### PR TITLE
Remove leftover prompt to run optional tests

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -187,10 +187,6 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Re-run the Optional Tests on both the WPiOS and WPAndroid PRs.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
 <p>o Main apps PRs should be ready to merge to their <code>develop</code> branches now. Merge them or get them merged.</p>
 <!-- /wp:paragraph -->
 


### PR DESCRIPTION
Follow-up to https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/72. This removes a leftover instruction to run optional tests on the main app PRs. This was inadvertently left out of the previous PR.