### PR TITLE
Add check main apps release notes step in checklist template

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -87,6 +87,10 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
+<p>o Review and update <code>RELEASE-NOTES.txt</code> file on both WPAndroid and WPiOS PRs so it includes all user-facing changes introduced in the release.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
 <p>o Verify the WPAndroid PR build succeeds. If PR CI tasks include a 403 error related to an inability to resolve the <code>react-native-bridge</code> dependency, you must wait for the <code>Build Android RN Bridge &amp; Publish to S3</code> task to succeed in gutenberg-mobile and then restart the WPAndroid CI tasks.</p>
 <!-- /wp:paragraph -->  
 


### PR DESCRIPTION
This step will help us to prevent overlooking updating the release notes of the main apps.