### PR TITLE
Update test plan to only include smoke testing

### DIFF
--- a/release_pull_request.md
+++ b/release_pull_request.md
@@ -27,10 +27,7 @@ No extra PRs yet. 🎉
 
 ## Test plan
 
-- Use the main WP apps to test the changes above.
-- Smoke test the main WP apps for [general writing flow](https://github.com/wordpress-mobile/test-cases/tree/master/test-cases/gutenberg/writing-flow).
-- Test the Unsupported Block Editor on WP Apps ([see steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/unsupported-block-editing.md#unsupported-block-editing---test-cases)).
-- Sanity [test suites](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-suites/gutenberg/sanity-test-suites.md) for WP Apps should be completed for each platform.
+Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.
 
 ## Release Submission Checklist
 


### PR DESCRIPTION
Previously we did extensive testing on the Gutenberg Mobile release before it is merged into the main apps. Nowadays, we only do minimal testing of release to ensure the editor is not broken, then make the release, then do more thorough testing of the editor that's included in the main app beta builds.

This updates the release PR templates to reflect the change.