### PR TITLE
Add a clean-up step to close the release milestone

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -243,6 +243,10 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- wp:paragraph -->
 <p>o Update the <code>gutenberg/after_X.XX.X</code> branches and open a PR against <code>develop</code>. If the branches are empty we’ll just delete them. The PR can actually get created as soon as something gets merged to the <code>gutenberg/after_X.XX.X</code> branches. Merge the <code>gutenberg/after_X.XX.X</code> PR(s) only <em>AFTER</em> the main apps have cut their release branches.</p>
 <!-- /wp:paragraph -->
+  
+<!-- wp:paragraph -->
+<p>o Close the <a href="https://github.com/wordpress-mobile/gutenberg-mobile/milestones">Gutenberg Mobile milestone</a> that corresponds to this release.</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
 <h3>Test the Release</h3>

--- a/Releasing.md
+++ b/Releasing.md
@@ -207,6 +207,10 @@ For the body of the post, just copy this checklist and again replace all occurre
 <blockquote class="wp-block-quote"><p>Hey team. I wanted to let you know that the mobile Gutenberg team has finished integrating the X.XX.X Gutenberg release into the WPiOS and WPAndroid `release/XX.X` branches, ready for a new beta when you are available. Please let me know if you have any questions. Thanks! </p></blockquote>
 <!-- /wp:quote --></div>
 <!-- /wp:group -->
+  
+<!-- wp:paragraph -->
+<p>o Close the <a href="https://github.com/wordpress-mobile/gutenberg-mobile/milestones">Gutenberg Mobile milestone</a> that corresponds to this release.</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
 <h3>Sync the Release to Development Branches</h3>
@@ -242,10 +246,6 @@ For the body of the post, just copy this checklist and again replace all occurre
 
 <!-- wp:paragraph -->
 <p>o Update the <code>gutenberg/after_X.XX.X</code> branches and open a PR against <code>develop</code>. If the branches are empty we’ll just delete them. The PR can actually get created as soon as something gets merged to the <code>gutenberg/after_X.XX.X</code> branches. Merge the <code>gutenberg/after_X.XX.X</code> PR(s) only <em>AFTER</em> the main apps have cut their release branches.</p>
-<!-- /wp:paragraph -->
-  
-<!-- wp:paragraph -->
-<p>o Close the <a href="https://github.com/wordpress-mobile/gutenberg-mobile/milestones">Gutenberg Mobile milestone</a> that corresponds to this release.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->


### PR DESCRIPTION
Adds a clean-up step to close the release milestone. I added at the earliest point in the release after the main app builds have been cut.