### PR TITLE
Add support for multiple cherry-picks

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -157,12 +157,16 @@ cd ..
 
 # Ask if a cherry-pick is needed before bundling (for example if this is a hotfix release)
 cd gutenberg
-read -r -p "Do you want to cherry-pick a commit from gutenberg? (y/n) " -n 1
-echo ""
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-    read -r -p "Enter the commit hash to cherry-pick: " GUTENBERG_COMMIT_HASH_TO_CHERRY_PICK
-    execute "git" "cherry-pick" "$GUTENBERG_COMMIT_HASH_TO_CHERRY_PICK"
-fi
+CHERRY_PICK_PROMPT="Do you want to cherry-pick a commit from gutenberg? (y/n) " 
+while
+  read -r -p "$CHERRY_PICK_PROMPT" -n 1
+  echo ""
+  [[ $REPLY =~ ^[Yy]$ ]]
+do
+  read -r -p "Enter the commit hash to cherry-pick: " GUTENBERG_COMMIT_HASH_TO_CHERRY_PICK
+  execute "git" "cherry-pick" "$GUTENBERG_COMMIT_HASH_TO_CHERRY_PICK"
+  CHERRY_PICK_PROMPT="Do you want to cherry-pick another commit from gutenberg? (y/n) " 
+done
 cd ..
 
 # Commit updates to gutenberg submodule


### PR DESCRIPTION
### Description

Often our betafix releases will require that multiple commits are cherry-picked into the Gutenberg branch. This PR enables that from the script so that it doesn't have to be done manually.

#### To test

Run the release script with a bogus version (can append something like `-test` onto the end) and when the prompt comes up for cherry-picking, each response with "Y" should allow a cherry-pick hash to be entered. Then the script should continue asking if more cherry-picking is desired, until the user enters "N" (or something other than "Y" or "y").

After the cherry-picking step, it is enough to `cd` into the `gutenberg` directory to check that indeed the multiple commits were cherry-picked. If any local branches are created during this testing, they can be manually deleted (and it should not be necessary to create any PRs for testing this part of the script).