### PR TITLE
Update main apps default target branch to `trunk`

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -17,8 +17,8 @@ WPIOS_PR_LABEL="Gutenberg integration"
 # 3. Ensure that each of your repos contains the target branch listed below:
 GUTENBERG_MOBILE_TARGET_BRANCH="trunk"
 GUTENBERG_TARGET_BRANCH="trunk"
-WPANDROID_TARGET_BRANCH="develop"
-WPIOS_TARGET_BRANCH="develop"
+WPANDROID_TARGET_BRANCH="trunk"
+WPIOS_TARGET_BRANCH="trunk"
 # 4. Update the repo names below to the user repo name for your fork
 GUTENBERG_REPO="WordPress"
 MOBILE_REPO="wordpress-mobile"


### PR DESCRIPTION
Recently the `develop` branch in the main apps (WordPress-iOS and WordPress-Android) has been renamed to `trunk`. For this reason, this PR updates the release script to use `trunk` as the default target branch of main apps for the release PRs.