### PR TITLE
Add util `execute_until_succeeds` command and use it for retrying iOS dependency install

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -294,7 +294,7 @@ test -f "Podfile" || abort "Error: Could not find Podfile"
 sed -i'.orig' -E "s/wordpress-mobile(\/gutenberg-mobile)/$MOBILE_REPO\1/" Podfile || abort "Error: Failed updating GitHub organization in Podfile"
 sed -i'.orig' -E "s/gutenberg :(commit|tag) => '(.*)'/gutenberg :commit => '$GB_MOBILE_PR_REF'/" Podfile || abort "Error: Failed updating gutenberg ref in Podfile"
 execute "bundle" "install"
-execute "rake" "dependencies"
+execute_until_succeeds "rake" "dependencies"
 
 
 execute "git" "add" "Podfile" "Podfile.lock"

--- a/release_utils.sh
+++ b/release_utils.sh
@@ -53,6 +53,23 @@ execute() {
     fi
 }
 
+# Takes multiple arguments consisting a command and executes it.
+# If the command is not successful, it will be retried for a maximum of 10 times.
+# In case it keeps failing, the script will be aborted, printing the failed command
+# and its arguments in a colored format.
+#
+# Returns the executed command's result if it's successful.
+execute_until_succeeds() {
+    local max_retry=10
+    local retry_count=0
+    until "$@"
+    do
+        sleep 1
+        [[ retry_count -eq "$max_retry" ]] && abort "$(printf "Failed after retrying $retry_count times: %s" "$(shell_join "$@")")"
+        ((retry_count++))
+        warn "Retrying '$(shell_join "$@")' command after $retry_count times..."
+    done
+}
 
 #####
 # Confirm to Proceed Prompt


### PR DESCRIPTION
I very often experience errors when running the release command, specifically when installing iOS dependencies via the `rake dependencies` command. For this reason, I decided to add a new util command that retries the passed command until it succeeds (with a maximum of 10 retries count).

In order to test this in isolation:
1. Create a `test.sh` script file.
2. Add the following code:
```
set -e
source ./release_utils.sh

times=0
function fail_after_5_times() {
    echo "This command will fail 5 times until succeeds (params: $@).\n"

    if [[ times -lt 5 ]]; then 
        ((times++))
        return 1
    fi
    echo "Command succeed!"
}

execute_until_succeeds "fail_after_5_times" "param-1" "param-2"
```
3. Run `chmod +x test.sh`.
4. Run `./test.sh`.
5. Observe that the command is retried 5 times until succeeds.