### PR TITLE
Prevent including changes that only affect a single platform in release notes of other platforms

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -83,7 +83,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>o Review and update <code>RELEASE-NOTES.txt</code> file on both WPAndroid and WPiOS PRs so it includes all user-facing changes introduced in the release.</p>
+<p>o Review and update <code>RELEASE-NOTES.txt</code> file on both WPAndroid and WPiOS PRs so it includes all user-facing changes introduced in the release. Keep in mind that some changes can be specific to a single platform, so they should only be added to the release notes of the platform that affects (e.g. a change that only affects Android should only be included in WPAndroid release notes).</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
In relation to the step related to reviewing and updating the release notes of main apps, we don't specify that the changes specific to a platform should only be included in that platform. There have been some cases, in previous releases, where we wrongly introduced changes in WPiOS release notes that only affected Android and the other way around.

In order to prevent this, this PR expands the checklist step, noting that platform-specific changes should only be included in release notes of the platform that affects.