### PR TITLE
Add warning about possible WPiOS errors

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -38,7 +38,9 @@ source ./release_utils.sh
 
 # Warn about possible WPiOS errors
 echo ""
-echo "This script will fail when generating the WPiOS PR if your local machine cannot successfully obtain the WPiOS dependencies. For that reason, if you want the script to generate WPiOS PRs, it is STRONGLY recommended that you verify that you can run 'bundle install; rake dependencies' on your local machine from the the WPiOS project's trunk branch before proceeding with the script. Otherwise, the script may fail in the middle of running, and no one wants that."
+echo "This script will fail when generating the WPiOS PR if your local machine cannot successfully obtain the WPiOS dependencies." 
+echo "For that reason, if you want the script to generate WPiOS PRs, it is STRONGLY recommended that you verify that you can run 'bundle install && rake dependencies' on your local machine from the the WPiOS project's trunk branch before proceeding with the script." 
+echo "Otherwise, the script may fail in the middle of running, and no one wants that."
 read -r -p "Are you ready to proceed with the script? (y/n) "
 echo ""
 if ! [[ $REPLY =~ ^[Yy]$ ]]; then

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -39,7 +39,7 @@ source ./release_utils.sh
 # Warn about possible WPiOS errors
 echo ""
 echo "This script will fail when generating the WPiOS PR if your local machine cannot successfully obtain the WPiOS dependencies. For that reason, if you want the script to generate WPiOS PRs, it is STRONGLY recommended that you verify that you can run 'bundle install; rake dependencies' on your local machine from the the WPiOS project's trunk branch before proceeding with the script. Otherwise, the script may fail in the middle of running, and no one wants that."
-read -r -p "Are you ready to proceed with the script? (y/n) " -n 1
+read -r -p "Are you ready to proceed with the script? (y/n) "
 echo ""
 if ! [[ $REPLY =~ ^[Yy]$ ]]; then
     abort "Exiting script..."

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -34,6 +34,17 @@ MOBILE_REPO="wordpress-mobile"
 
 set -e
 
+source ./release_utils.sh
+
+# Warn about possible WPiOS errors
+echo ""
+echo "This script will fail when generating the WPiOS PR if your local machine cannot successfully obtain the WPiOS dependencies. For that reason, if you want the script to generate WPiOS PRs, it is STRONGLY recommended that you verify that you can run 'bundle install; rake dependencies' on your local machine from the the WPiOS project's trunk branch before proceeding with the script. Otherwise, the script may fail in the middle of running, and no one wants that."
+read -r -p "Are you ready to proceed with the script? (y/n) " -n 1
+echo ""
+if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+    abort "Exiting script..."
+fi
+
 # Read GB-Mobile PR template
 PR_TEMPLATE_PATH='./release_pull_request.md'
 test -f "$PR_TEMPLATE_PATH" || abort "Error: Could not find PR template at $PR_TEMPLATE_PATH"
@@ -51,7 +62,6 @@ if [[ ! "$GB_MOBILE_PATH" == *gutenberg-mobile ]]; then
     abort "Error path does not end with gutenberg-mobile"
 fi
 
-source ./release_utils.sh
 source ./release_prechecks.sh "$GB_MOBILE_PATH"
 
 # Execute script commands from gutenberg-mobile directory


### PR DESCRIPTION
This is adding a warning and advising anyone running the script to make sure they can get the WPiOS dependencies before proceeding as discussed [here](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/62#issuecomment-1027978731). 

This is just quick and dirty, better than nothing, workaround. We should remove this once we figure out how to make the script more robust so that these errors don't occur (ongoing discussion in https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/62 and https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/52). Until then, it seems better to warn about the error and request a very slight bit of manual work to avoid the risk of the script failing and us having to manually create the WPiOS and WPAndroid PRs.