### PR TITLE
Check if script is updated

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -38,14 +38,26 @@ SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_PATH"
 source ./release_utils.sh
 
+
+# Check if script is up-to-date
 LOCAL_COMMIT=$(git rev-parse HEAD)
 git remote update
 DEVELOP_BRANCH_HEAD=$(git rev-parse ${1:-'develop@{upstream}'})
-
 if ! [[ $LOCAL_COMMIT = $DEVELOP_BRANCH_HEAD ]]; then
     echo ""
     echo "You're not running this script from the HEAD commit on the develop branch." 
-    echo "If you are generating a release you should always use the latest version of the script."
+    echo "If you are generating a release you should generally use the latest version of the script."
+    read -r -p "Are you sure you want the script to proceed? (y/n) "
+    echo ""
+    if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+        abort "Exiting script..."
+    fi
+fi
+
+# Check if script has uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then 
+    echo "You are running this script with uncommitted changes."
+    echo "If you are generating a release you should generally use the current version of the script on the develop branch."
     read -r -p "Are you sure you want the script to proceed? (y/n) "
     echo ""
     if ! [[ $REPLY =~ ^[Yy]$ ]]; then

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -42,8 +42,7 @@ source ./release_utils.sh
 # Check if script is up-to-date
 LOCAL_COMMIT=$(git rev-parse HEAD)
 execute "git" "remote" "update"
-DEVELOP_BRANCH=${1:-'develop@{upstream}'}
-DEVELOP_BRANCH_HEAD=$(git rev-parse "$DEVELOP_BRANCH")
+DEVELOP_BRANCH_HEAD=$(git rev-parse 'develop@{upstream}')
 if ! [[ "$LOCAL_COMMIT" = "$DEVELOP_BRANCH_HEAD" ]]; then
     echo ""
     echo "You're not running this script from the HEAD commit on the develop branch." 

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -34,12 +34,30 @@ MOBILE_REPO="wordpress-mobile"
 
 set -e
 
+SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$SCRIPT_PATH"
+source ./release_utils.sh
+
+LOCAL_COMMIT=$(git rev-parse HEAD)
+git remote update
+DEVELOP_BRANCH_HEAD=$(git rev-parse ${1:-'develop@{upstream}'})
+
+if ! [[ $LOCAL_COMMIT = $DEVELOP_BRANCH_HEAD ]]; then
+    echo ""
+    echo "You're not running this script from the HEAD commit on the develop branch." 
+    echo "If you are generating a release you should always use the latest version of the script."
+    read -r -p "Are you sure you want the script to proceed? (y/n) "
+    echo ""
+    if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+        abort "Exiting script..."
+    fi
+fi
+
 # Read GB-Mobile PR template
 PR_TEMPLATE_PATH='./release_pull_request.md'
 test -f "$PR_TEMPLATE_PATH" || abort "Error: Could not find PR template at $PR_TEMPLATE_PATH"
 PR_TEMPLATE=$(cat "$PR_TEMPLATE_PATH")
 
-SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Ask for path to gutenberg-mobile directory
 # (default is sibling directory of gutenberg-mobile-release-toolkit)
 DEFAULT_GB_MOBILE_LOCATION="$SCRIPT_PATH/../gutenberg-mobile"
@@ -51,7 +69,6 @@ if [[ ! "$GB_MOBILE_PATH" == *gutenberg-mobile ]]; then
     abort "Error path does not end with gutenberg-mobile"
 fi
 
-source ./release_utils.sh
 source ./release_prechecks.sh "$GB_MOBILE_PATH"
 
 # Execute script commands from gutenberg-mobile directory

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -42,7 +42,8 @@ source ./release_utils.sh
 # Check if script is up-to-date
 LOCAL_COMMIT=$(git rev-parse HEAD)
 git remote update
-DEVELOP_BRANCH_HEAD=$(git rev-parse ${1:-'develop@{upstream}'})
+DEVELOP_BRANCH=${1:-'develop@{upstream}'}
+DEVELOP_BRANCH_HEAD=$(git rev-parse "$DEVELOP_BRANCH")
 if ! [[ "$LOCAL_COMMIT" = "$DEVELOP_BRANCH_HEAD" ]]; then
     echo ""
     echo "You're not running this script from the HEAD commit on the develop branch." 

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -41,7 +41,7 @@ source ./release_utils.sh
 
 # Check if script is up-to-date
 LOCAL_COMMIT=$(git rev-parse HEAD)
-git remote update
+execute "git" "remote" "update"
 DEVELOP_BRANCH=${1:-'develop@{upstream}'}
 DEVELOP_BRANCH_HEAD=$(git rev-parse "$DEVELOP_BRANCH")
 if ! [[ "$LOCAL_COMMIT" = "$DEVELOP_BRANCH_HEAD" ]]; then

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -43,7 +43,7 @@ source ./release_utils.sh
 LOCAL_COMMIT=$(git rev-parse HEAD)
 git remote update
 DEVELOP_BRANCH_HEAD=$(git rev-parse ${1:-'develop@{upstream}'})
-if ! [[ $LOCAL_COMMIT = $DEVELOP_BRANCH_HEAD ]]; then
+if ! [[ "$LOCAL_COMMIT" = "$DEVELOP_BRANCH_HEAD" ]]; then
     echo ""
     echo "You're not running this script from the HEAD commit on the develop branch." 
     echo "If you are generating a release you should generally use the latest version of the script."


### PR DESCRIPTION
Just adding some checks to check whether the script is unmodified from the remote develop branch. I thought this would be a good idea to make sure someone doesn't accidentally run the script with changes. I made these prompts instead of automatically exiting the script in order to avoid making it too difficult to test changes to the script (of course you could also just comment out these changes while you were testing).

When testing this it may be helpful to modify`${1:-'develop@{upstream}'}` to refer to this PR's branch (so`${1:-'make-sure-script-is-updated@{upstream}'}`.

#### Expected Behavior

| | same commit as remote branch | different commit from remote branch
| --- | --- | ---
| **NO uncomitted changes** | no new prompts | 1 new prompt about not using the HEAD of the remote develop branch
| **uncommited changes** | 1 new prompt about uncommited changes | 2 new prompts: not using HEAD of remote develop and uncommited changes