### PR TITLE
Fix markup typo

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -220,6 +220,7 @@ For the body of the post, just copy this checklist and again replace all occurre
 
 <!-- wp:paragraph -->
 <p>o Update the gutenberg reference on the gutenberg-mobile release branch to point to the Gutenberg PR merge commit</p>
+<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>o Merge the <strong>gutenberg-mobile</strong> PR to <code>trunk</code>. Use "Create a merge commit" option when merging to avoid losing any commit history from the release branch.</p>


### PR DESCRIPTION
Add the missing closing tag.  

To test: 

- Copy the checklist
- Paste into a P2 editor
- The list should be complete.