### PR TITLE
Add verify aztec script

### DIFF
--- a/verify_aztec_version.sh
+++ b/verify_aztec_version.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -n "${GBM_DEBUG:-}" ]]; then
+    set -x
+fi
+
+GBM_REPO=${GBM_REPO:="wordpress-mobile/gutenberg-mobile"}
+GB_REPO=${GB_REPO:="WordPress/gutenberg"}
+
+gbm_branch=${1:-"trunk"}
+gb_sha=${2:-}
+
+fetch_aztec_version() {
+  # temporarily remove the pipefail so grep doesn't exit when there is no match
+  set +o pipefail
+  local source="$1"
+  local version_key="$2"
+  curl -s "$source" | grep "$version_key" | head -1 | grep -oE "\d+.\d+.\d+" | cat
+  set -o pipefail
+}
+
+if [[ -z "$gb_sha" ]]; then
+  gbm_tree_sha=$(gh api "/repos/${GBM_REPO}/commits/trunk" -q '.commit.tree.sha')
+  gb_sha=$(gh api "/repos/${GBM_REPO}/git/trees/${gbm_tree_sha}" -q '.tree | .[] | select(.path == "gutenberg") | .sha')
+fi
+
+aztec_android_gradle_url="https://raw.githubusercontent.com/${GB_REPO}/${gb_sha}/packages/react-native-aztec/android/build.gradle"
+aztec_android_version=$(fetch_aztec_version "$aztec_android_gradle_url" "aztecVersion")
+
+if [[ -z "$aztec_android_version" ]]; then
+  echo "A release version for WordPress-Aztec-Android was not found in $aztec_android_gradle_url"
+fi
+
+aztec_ios_podspec_url="https://raw.githubusercontent.com/${GBM_REPO}/${gbm_branch}/RNTAztecView.podspec"
+aztec_ios_version=$(fetch_aztec_version "$aztec_ios_podspec_url" "WordPress-Aztec-iOS")
+if [[ -z "$aztec_ios_version" ]]; then
+  echo "A release version for WordPress-Aztec-iOS was not found in $aztec_ios_podspec_url"
+fi

--- a/verify_aztec_version.sh
+++ b/verify_aztec_version.sh
@@ -21,7 +21,7 @@ fetch_aztec_version() {
 }
 
 if [[ -z "$gb_sha" ]]; then
-  gbm_tree_sha=$(gh api "/repos/${GBM_REPO_OWNER}/gutenberg-mobile/commits/trunk" -q '.commit.tree.sha')
+  gbm_tree_sha=$(gh api "/repos/${GBM_REPO_OWNER}/gutenberg-mobile/commits/${gbm_branch}" -q '.commit.tree.sha')
   gb_sha=$(gh api "/repos/${GBM_REPO_OWNER}/gutenberg-mobile/git/trees/${gbm_tree_sha}" -q '.tree | .[] | select(.path == "gutenberg") | .sha')
 fi
 

--- a/verify_aztec_version.sh
+++ b/verify_aztec_version.sh
@@ -32,7 +32,7 @@ if [[ -z "$aztec_android_version" ]]; then
   echo "A release version for WordPress-Aztec-Android was not found in $aztec_android_gradle_url"
 fi
 
-aztec_ios_podspec_url="https://raw.githubusercontent.com/${GBM_REPO_OWNER}/gutenberg/${gbm_branch}/RNTAztecView.podspec"
+aztec_ios_podspec_url="https://raw.githubusercontent.com/${GBM_REPO_OWNER}/gutenberg-mobile/${gbm_branch}/RNTAztecView.podspec"
 aztec_ios_version=$(fetch_aztec_version "$aztec_ios_podspec_url" "WordPress-Aztec-iOS")
 if [[ -z "$aztec_ios_version" ]]; then
   echo "A release version for WordPress-Aztec-iOS was not found in $aztec_ios_podspec_url"

--- a/verify_aztec_version.sh
+++ b/verify_aztec_version.sh
@@ -16,7 +16,7 @@ fetch_aztec_version() {
   set +o pipefail
   local source="$1"
   local version_key="$2"
-  curl -s "$source" | grep "$version_key" | head -1 | grep -oE "\d+.\d+.\d+" | cat
+  curl -sSL "$source" | grep "$version_key" | head -1 | grep -oE "\d+.\d+.\d+" | cat
   set -o pipefail
 }
 

--- a/verify_aztec_version.sh
+++ b/verify_aztec_version.sh
@@ -4,6 +4,24 @@ set -euo pipefail
 if [[ -n "${GBM_DEBUG:-}" ]]; then
     set -x
 fi
+# Aztec Version Check
+#
+# Checks for the latest version of Aztec for Android and iOS
+# If ran inside of the Gutenberg Mobile directory, it will check local files.
+# Otherwise it will fetch the versions from Gutenberg and Gutenberg Mobile origin repos.
+#
+# A warning message will be displayed if the version on either platform can not be verified.
+#
+# Usage: ./verify_aztec_version.sh [GBM branch] [GB commit sha]
+#
+# Options:
+#   [GBM branch] The GB mobile branch to check. Defaults to trunk.
+#   [GB commit sha] The GB commit sha to check. Defaults to revision of Gutenberg that is in the GBM branch.
+#
+# Environment Variables:
+#  GBM_GUTENBERG_OWNER: The owner of the Gutenberg repo. Defaults to WordPress.
+#  GBM_WP_MOBILE_OWNER: The owner of the Gutenberg Mobile repo. Defaults to WordPress.
+
 
 GBM_REPO_OWNER=${GBM_REPO:="wordpress-mobile"}
 GB_REPO_OWNER=${GB_REPO:="WordPress"}
@@ -16,24 +34,34 @@ fetch_aztec_version() {
   set +o pipefail
   local source="$1"
   local version_key="$2"
-  curl -sSL "$source" | grep "$version_key" | head -1 | grep -oE "\d+.\d+.\d+" | cat
+  curl -sSL "$source" 2>/dev/null || cat "$source" | grep "$version_key" | head -1 | grep -oE "\d+.\d+.\d+" | cat
   set -o pipefail
 }
 
-if [[ -z "$gb_sha" ]]; then
+
+## Check for Android Aztec version.
+aztec_android_gradle_source="$(pwd)/gutenberg/packages/react-native-aztec/build.gradle"
+if [[ -z "$gb_sha" ]] || [[ ! -f "$aztec_android_gradle_source" ]]; then
   gbm_tree_sha=$(gh api "/repos/${GBM_REPO_OWNER}/gutenberg-mobile/commits/${gbm_branch}" -q '.commit.tree.sha')
   gb_sha=$(gh api "/repos/${GBM_REPO_OWNER}/gutenberg-mobile/git/trees/${gbm_tree_sha}" -q '.tree | .[] | select(.path == "gutenberg") | .sha')
 fi
 
-aztec_android_gradle_url="https://raw.githubusercontent.com/${GB_REPO_OWNER}/gutenberg/${gb_sha}/packages/react-native-aztec/android/build.gradle"
-aztec_android_version=$(fetch_aztec_version "$aztec_android_gradle_url" "aztecVersion")
-
-if [[ -z "$aztec_android_version" ]]; then
-  echo "A release version for WordPress-Aztec-Android was not found in $aztec_android_gradle_url"
+if [[ ! -f "$aztec_android_gradle_source" ]]; then
+  aztec_android_gradle_source="https://raw.githubusercontent.com/${GB_REPO_OWNER}/gutenberg/${gb_sha}/packages/react-native-aztec/android/build.gradle"
 fi
 
-aztec_ios_podspec_url="https://raw.githubusercontent.com/${GBM_REPO_OWNER}/gutenberg-mobile/${gbm_branch}/RNTAztecView.podspec"
-aztec_ios_version=$(fetch_aztec_version "$aztec_ios_podspec_url" "WordPress-Aztec-iOS")
+aztec_android_version=$(fetch_aztec_version "$aztec_android_gradle_source" "aztecVersion")
+
+if [[ -z "$aztec_android_version" ]]; then
+  echo "A release version for WordPress-Aztec-Android was not found in $aztec_android_gradle_source"
+fi
+
+## Chekc for iOS Aztex version.
+aztec_ios_podspec_source="$(pwd)/RNTAztecView.podspec"
+if [[ ! -f "$aztec_ios_podspec_source" ]]; then
+  aztec_ios_podspec_source="https://raw.githubusercontent.com/${GBM_REPO_OWNER}/gutenberg-mobile/${gbm_branch}/RNTAztecView.podspec"
+fi
+aztec_ios_version=$(fetch_aztec_version "$aztec_ios_podspec_source" "WordPress-Aztec-iOS")
 if [[ -z "$aztec_ios_version" ]]; then
-  echo "A release version for WordPress-Aztec-iOS was not found in $aztec_ios_podspec_url"
+  echo "A release version for WordPress-Aztec-iOS was not found in $aztec_ios_podspec_source"
 fi

--- a/verify_aztec_version.sh
+++ b/verify_aztec_version.sh
@@ -5,8 +5,8 @@ if [[ -n "${GBM_DEBUG:-}" ]]; then
     set -x
 fi
 
-GBM_REPO=${GBM_REPO:="wordpress-mobile/gutenberg-mobile"}
-GB_REPO=${GB_REPO:="WordPress/gutenberg"}
+GBM_REPO_OWNER=${GBM_REPO:="wordpress-mobile"}
+GB_REPO_OWNER=${GB_REPO:="WordPress"}
 
 gbm_branch=${1:-"trunk"}
 gb_sha=${2:-}
@@ -21,18 +21,18 @@ fetch_aztec_version() {
 }
 
 if [[ -z "$gb_sha" ]]; then
-  gbm_tree_sha=$(gh api "/repos/${GBM_REPO}/commits/trunk" -q '.commit.tree.sha')
-  gb_sha=$(gh api "/repos/${GBM_REPO}/git/trees/${gbm_tree_sha}" -q '.tree | .[] | select(.path == "gutenberg") | .sha')
+  gbm_tree_sha=$(gh api "/repos/${GBM_REPO_OWNER}/gutenberg-mobile/commits/trunk" -q '.commit.tree.sha')
+  gb_sha=$(gh api "/repos/${GBM_REPO_OWNER}/gutenberg-mobile/git/trees/${gbm_tree_sha}" -q '.tree | .[] | select(.path == "gutenberg") | .sha')
 fi
 
-aztec_android_gradle_url="https://raw.githubusercontent.com/${GB_REPO}/${gb_sha}/packages/react-native-aztec/android/build.gradle"
+aztec_android_gradle_url="https://raw.githubusercontent.com/${GB_REPO_OWNER}/gutenberg/${gb_sha}/packages/react-native-aztec/android/build.gradle"
 aztec_android_version=$(fetch_aztec_version "$aztec_android_gradle_url" "aztecVersion")
 
 if [[ -z "$aztec_android_version" ]]; then
   echo "A release version for WordPress-Aztec-Android was not found in $aztec_android_gradle_url"
 fi
 
-aztec_ios_podspec_url="https://raw.githubusercontent.com/${GBM_REPO}/${gbm_branch}/RNTAztecView.podspec"
+aztec_ios_podspec_url="https://raw.githubusercontent.com/${GBM_REPO_OWNER}/gutenberg/${gbm_branch}/RNTAztecView.podspec"
 aztec_ios_version=$(fetch_aztec_version "$aztec_ios_podspec_url" "WordPress-Aztec-iOS")
 if [[ -z "$aztec_ios_version" ]]; then
   echo "A release version for WordPress-Aztec-iOS was not found in $aztec_ios_podspec_url"


### PR DESCRIPTION
This extracts the verify aztec into a standalone script.

The verification of the release version is the same as the current pre check.  The fundamental change is that this script is not dependent on a local clone of the gutenberg or gutenberg mobile. Instead the gradle and podspec files are fetched from `raw.githubusercontent.com` endpoints in the gutenberg and gutenberg mobile repos.

### Options

``` ./verify_aztec_version.sh [gutenberg-mobile branch] [gutenberg commit sha] ```

#### Environment Variables

`GBM_DEBUG`  enables `set -x` for verbose debugging 
`GBM_REPO_OWNER`  sets the repo owner for gutenberg-mobile, defaults to `wordpress-mobile`
`GB_REPO_OWNER` sets the repo owner for gutenberg, defaults to `WordPress`

### Usage
 
```bash
# Fetch podspec from gutenberg-mobile/trunk 
# Fetch gradle file from HEAD of the gutenberg submodule in gutenberg-mobile/trunk
$ ./verify_aztec_version.sh 

# Fetch podspec from gutenberg-mobile/release/1.0.0 
# Fetch gradle file from HEAD of the gutenberg submodule in gutenberg/release/1.0.0
$ ./verify_aztec_version.sh release/1.0.0

# Fetch podspec from gutneberg-mobile/any-branch
# Fetch gradle file from gutenberg at {commit_sha}
$ ./verify_aztec_verision.sh any-branch {commit_sha}
```
If the version can not be verified for either platform a warning message is printed. Otherwise nothing is echoed.

### Handling Version Issues Example

```bash
verify_aztec=$(./verify_aztec_version.sh)
if [[ $(echo "$verify_aztec" | wc -l | xargs) -gt "0" ]] ; then 
  echo "There is an issue verifying Aztec:"
  echo $output
fi
```
