### PR TITLE
Fix WP-Android and WP-iOS PR creation in release script

### DIFF
--- a/release_automation.sh
+++ b/release_automation.sh
@@ -343,7 +343,7 @@ execute "bundle" "install"
 execute_until_succeeds "rake" "dependencies"
 
 
-execute "git" "add" "Podfile" "Podfile.lock"
+execute "git" "add" "Podfile" "Podfile.lock" "$version_file"
 execute "git" "commit" "-m" "Release script: Update gutenberg-mobile ref"
 
 ohai "Push integration branch"

--- a/release_automation.sh
+++ b/release_automation.sh
@@ -12,8 +12,8 @@
 # 2. Insure that each of your forked repos contains the PR labels specified below:
 GUTENBERG_MOBILE_PR_LABEL="release-process"
 GUTENBERG_PR_LABEL="Mobile App - i.e. Android or iOS"
-WPANDROID_PR_LABEL="gutenberg-mobile"
-WPIOS_PR_LABEL="Gutenberg integration"
+WPANDROID_PR_LABEL="Gutenberg"
+WPIOS_PR_LABEL="Gutenberg"
 # 3. Ensure that each of your repos contains the target branch listed below:
 GUTENBERG_MOBILE_TARGET_BRANCH="trunk"
 GUTENBERG_TARGET_BRANCH="trunk"


### PR DESCRIPTION
This PR introduces the following fixes to the release script:
- Update the PR labels used in WP-Android and WP-IOS.
- Commits the file `Gutenberg/version.rb` after updating the Gutenberg reference (related to https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/114).