### PR TITLE
CLI Add template renderer 

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"embed"
+
+	"github.com/wordpress-mobile/gbm-cli/pkg/render"
+)
+
+//go:embed templates/*
+var templatesFS embed.FS
+
+func main() {
+	render.TemplateFS = templatesFS
+}

--- a/cli/pkg/render/render.go
+++ b/cli/pkg/render/render.go
@@ -1,0 +1,31 @@
+package render
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"text/template"
+)
+
+var TemplateFS embed.FS
+
+func Render(templatePath string, rawJSON string) (string, error) {
+
+	var data map[string]interface{}
+
+	if err := json.Unmarshal([]byte(rawJSON), &data); err != nil {
+		return "", err
+	}
+
+	tmpl, err := template.ParseFS(TemplateFS, templatePath)
+	if err != nil {
+		return "", err
+	}
+
+	var result bytes.Buffer
+	if err := tmpl.Execute(&result, data); err != nil {
+		return "", nil
+	}
+
+	return result.String(), nil
+}

--- a/cli/pkg/render/render_test.go
+++ b/cli/pkg/render/render_test.go
@@ -1,0 +1,65 @@
+package render
+
+import (
+	"embed"
+	"testing"
+)
+
+//go:embed testdata/*
+var templatesFS embed.FS
+
+func init() {
+	TemplateFS = templatesFS
+}
+
+func TestRender(t *testing.T) {
+
+	t.Run("It renders a template with the given JSON", func(t *testing.T) {
+		templatePath := "testdata/test_template.txt"
+		rawJSON := `{"world": "World"}`
+
+		got, err := Render(templatePath, rawJSON)
+		assertNoError(t, err)
+
+		if got != "Hello World" {
+			t.Fatalf("Expected %s, got %s", "Hello World\n", got)
+		}
+	})
+
+	t.Run("It returns an error if the JSON is invalid", func(t *testing.T) {
+		templatePath := "testdata/test_template.txt"
+		rawJSON := `{"world": "World"`
+
+		_, err := Render(templatePath, rawJSON)
+		assertError(t, err)
+	})
+
+	t.Run("It returns an error if the template is invalid", func(t *testing.T) {
+		templatePath := "testdata/invalid_template.txt"
+		rawJSON := `{"world": "World"}`
+
+		_, err := Render(templatePath, rawJSON)
+		assertError(t, err)
+	})
+
+	t.Run("It returns an error if the template is missing", func(t *testing.T) {
+		templatePath := "testdata/missing_template.txt"
+		rawJSON := `{"world": "World"}`
+		_, err := Render(templatePath, rawJSON)
+		assertError(t, err)
+	})
+}
+
+func assertError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("Expected an error, got nil")
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}

--- a/cli/pkg/render/testdata/invalid_template.txt
+++ b/cli/pkg/render/testdata/invalid_template.txt
@@ -1,0 +1,1 @@
+hello {{ user.name }}

--- a/cli/pkg/render/testdata/test_template.txt
+++ b/cli/pkg/render/testdata/test_template.txt
@@ -1,0 +1,1 @@
+Hello {{ .world }}


### PR DESCRIPTION
This add a render package to render go templates
The renderer uses JSON for the template data.
This reduces the type checking but will make it easier to integrate new templates without having to maintain structs for every template

This also introduces a project main function. Right now all it does is set up the `./templates` directory as an embedded directory for when the app is compiled

Testing 
Run `go test ./..` 
