### PR TITLE
Add create GBM PR flow

### DIFF
--- a/cli/cmd/release/integrate.go
+++ b/cli/cmd/release/integrate.go
@@ -3,20 +3,11 @@ package release
 import (
 	"fmt"
 	"os"
-	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/internal/repo"
 	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release"
-)
-
-var (
-	Ios        bool
-	Android    bool
-	Update     bool
-	BaseBranch string
 )
 
 // checklistCmd represents the checklist command
@@ -28,84 +19,15 @@ var IntegrateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		version := args[0]
-		gbmPr, err := repo.GetGbmReleasePr(version)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
 
-		type result struct {
-			repo string
-			pr   repo.PullRequest
-			err  error
-		}
-		rChan := make(chan result)
+		results := integrate(version)
 
-		s := spinner.New(spinner.CharSets[23], 200*time.Millisecond)
-
-		setTempDir()
-		defer cleanup()
-
-		// if neither ios or android are specified, default to both
-		if !Ios && !Android {
-			Ios = true
-			Android = true
-		} else {
-			// if we are only doing one, set verbose to true
-			Verbose = true
-		}
-		numPr := 0 // number of PRs to create
-
-		// Use goroutines to create the PRs concurrently
-		if Ios {
-			numPr++
-			utils.LogInfo("Creating iOS PR at %s/Wordpress-iOS", repo.WpMobileOrg)
-			go func() {
-				pr, err := release.CreateIosPr(version, BaseBranch, TempDir, gbmPr, Verbose)
-				rChan <- result{"WordPress-iOS", pr, err}
-			}()
-		}
-
-		if Android {
-			numPr++
-			utils.LogInfo("Creating Android PR at %s/WordPress-Android", repo.WpMobileOrg)
-			go func() {
-				pr, err := release.CreateAndroidPr(version, BaseBranch, TempDir, gbmPr, Verbose)
-				rChan <- result{"WordPress-Android", pr, err}
-			}()
-		}
-
-		if !Verbose {
-			s.Start()
-			defer s.Stop()
-		}
-
-		success := true
-		for i := 0; i < numPr; i++ {
-			result := <-rChan
-			if result.err != nil {
-				if repo.IsExistingBranchError(result.err) {
-					utils.LogWarn("%s : Release branch already exists, try updating", result.repo)
-				} else {
-					utils.LogError("%v", result.err)
-				}
-			}
-
-			if result.pr.Number == 0 {
-				// There might be an error but let's consider
-				// creating the pr is a success
-				// TODO: Consider an existing branch as a success ?
-				success = false
+		for _, r := range results {
+			if r.err != nil {
+				utils.LogError("Error creating %s PR: %s", r.repo, r.err)
 			} else {
-				utils.LogInfo("PR created: %s", result.pr.Url)
+				utils.LogInfo("Created %s PR: %s", r.repo, r.pr.Url)
 			}
-		}
-
-		s.Stop()
-		if success {
-			utils.LogInfo("PRs created successfully")
-		} else {
-			utils.LogError("Some PRs failed to create")
 		}
 
 	},
@@ -117,4 +39,54 @@ func init() {
 	IntegrateCmd.Flags().BoolVarP(&Update, "update", "u", false, "update existing PR")
 	IntegrateCmd.Flags().StringVarP(&BaseBranch, "base-branch", "b", "trunk", "base branch for the PR")
 	IntegrateCmd.Flags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+}
+
+func integrate(version string) (results []releaseResult) {
+
+	gbmPr, err := repo.GetGbmReleasePr(version)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	rChan := make(chan releaseResult)
+
+	setTempDir()
+	defer cleanup()
+
+	// if neither ios or android are specified, default to both
+	if !Ios && !Android {
+		Ios = true
+		Android = true
+	} else {
+		// if we are only doing one, set verbose to true
+		Verbose = true
+	}
+	numPr := 0 // number of PRs to create
+
+	// Use goroutines to create the PRs concurrently
+	if Ios {
+		numPr++
+		utils.LogInfo("Creating iOS PR at %s/Wordpress-iOS", repo.WpMobileOrg)
+		go func() {
+			pr, err := release.CreateIosPr(version, BaseBranch, TempDir, gbmPr, Verbose)
+			rChan <- releaseResult{"WordPress-iOS", pr, err}
+		}()
+	}
+
+	if Android {
+		numPr++
+		utils.LogInfo("Creating Android PR at %s/WordPress-Android", repo.WpMobileOrg)
+		go func() {
+			pr, err := release.CreateAndroidPr(version, BaseBranch, TempDir, gbmPr, Verbose)
+			rChan <- releaseResult{"WordPress-Android", pr, err}
+		}()
+	}
+
+	for i := 0; i < numPr; i++ {
+		r := <-rChan
+		results = append(results, r)
+	}
+
+	return results
 }

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -49,7 +49,8 @@ var PrepareCmd = &cobra.Command{
 			utils.LogInfo("🏁 Gutenberg Mobile release ready to go, check it out: %s", gbmpr.Url)
 		}
 
-		if runIntegration {
+		// Make sure we only run the integration if we are also creating a gbm pr.
+		if Gbm && runIntegration {
 			intResults := integrate(version)
 			results = append(results, intResults...)
 		}

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -29,7 +29,7 @@ var PrepareCmd = &cobra.Command{
 
 		runIntegration := Apps || Android || Ios
 
-		if Gbm || runIntegration {
+		if Gbm && runIntegration {
 			utils.LogInfo("📦 Running full release pipeline. Let's go! 🚀")
 		}
 

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -33,12 +33,12 @@ var PrepareCmd = &cobra.Command{
 			utils.LogInfo("📦 Running full release pipeline. Let's go! 🚀")
 		}
 
-		gbpr, _ := release.CreateGbPR(version, TempDir, true)
+		gbpr, _ := release.CreateGbPR(version, TempDir, Verbose)
 
 		utils.LogInfo("🏁 Gutenberg release ready to go, check it out: %s", gbpr.Url)
 
 		if Gbm {
-			gbmpr, _ := release.CreateGbmPr(version, TempDir, true)
+			gbmpr, _ := release.CreateGbmPr(version, TempDir, Verbose)
 
 			utils.LogInfo("🏁 Gutenberg Mobile release ready to go, check it out: %s", gbmpr.Url)
 		}

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -61,5 +61,5 @@ func init() {
 	PrepareCmd.Flags().BoolVarP(&Apps, "integrate", "", false, "prepare ios and android prs")
 	PrepareCmd.Flags().BoolVarP(&Android, "android", "", false, "prepare android pr")
 	PrepareCmd.Flags().BoolVarP(&Ios, "ios", "", false, "prepare ios pr")
-	IntegrateCmd.Flags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	PrepareCmd.Flags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 }

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -27,9 +27,25 @@ var PrepareCmd = &cobra.Command{
 
 		var err error
 
+		runIntegration := Apps || Android || Ios
+
+		if Gbm || runIntegration {
+			utils.LogInfo("📦 Running full release pipeline. Let's go! 🚀")
+		}
+
 		gbpr, _ := release.CreateGbPR(version, TempDir, true)
 
 		utils.LogInfo("🏁 Gutenberg release ready to go, check it out: %s", gbpr.Url)
+
+		if Gbm {
+			gbmpr, _ := release.CreateGbmPr(version, TempDir, true)
+
+			utils.LogInfo("🏁 Gutenberg Mobile release ready to go, check it out: %s", gbmpr.Url)
+		}
+
+		if runIntegration {
+			IntegrateCmd.Run(cmd, []string{version})
+		}
 
 		utils.LogDebug("✔️ Done with %s", TempDir)
 
@@ -41,5 +57,9 @@ var PrepareCmd = &cobra.Command{
 }
 
 func init() {
+	PrepareCmd.Flags().BoolVarP(&Gbm, "gbm", "", false, "prepare gutenberg mobile pr")
+	PrepareCmd.Flags().BoolVarP(&Apps, "integrate", "", false, "prepare ios and android prs")
+	PrepareCmd.Flags().BoolVarP(&Android, "android", "", false, "prepare android pr")
+	PrepareCmd.Flags().BoolVarP(&Ios, "ios", "", false, "prepare ios pr")
 	IntegrateCmd.Flags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 }

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -1,6 +1,8 @@
 package release
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release"
@@ -23,6 +25,15 @@ var PrepareCmd = &cobra.Command{
 		var err error
 
 		runIntegration := Apps || Android || Ios
+
+		// Before we start let's make sure the someone didn't forget a flag
+		if runIntegration && !Gbm {
+			cont := utils.Confirm("🤔 You didn't specify --gbm but also included an integration flag. Continuing will only create the Gutenberg PR, are you sure?")
+			if !cont {
+				utils.LogInfo("👋 Bye!")
+				os.Exit(0)
+			}
+		}
 
 		if Gbm && runIntegration {
 			utils.LogInfo("📦 Running full release pipeline. Let's go! 🚀")
@@ -49,7 +60,6 @@ var PrepareCmd = &cobra.Command{
 			utils.LogInfo("🏁 Gutenberg Mobile release ready to go, check it out: %s", gbmpr.Url)
 		}
 
-		// Make sure we only run the integration if we are also creating a gbm pr.
 		if Gbm && runIntegration {
 			intResults := integrate(version)
 			results = append(results, intResults...)

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -34,7 +33,7 @@ func init() {
 
 func setTempDir() {
 	var err error
-	if TempDir, err = ioutil.TempDir("", "gbm-"); err != nil {
+	if TempDir, err = os.MkdirTemp("", "gbm-"); err != nil {
 		fmt.Println("Error creating temp dir")
 		os.Exit(1)
 	}

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -7,12 +7,31 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/internal/repo"
 )
 
 var (
 	TempDir string
 	Verbose bool
+
+	// Used by `integrate` and `prepare`
+	Ios     bool
+	Android bool
+
+	// Used by `integrate`
+	Update     bool
+	BaseBranch string
+
+	// Used by `prepare`
+	Gbm  bool
+	Apps bool
 )
+
+type releaseResult struct {
+	repo string
+	pr   repo.PullRequest
+	err  error
+}
 
 func cleanup() {
 	os.RemoveAll(TempDir)
@@ -57,4 +76,5 @@ func init() {
 	RootCmd.AddCommand(PrepareCmd)
 	RootCmd.AddCommand(IntegrateCmd)
 	RootCmd.AddCommand(StatusCmd)
+	RootCmd.AddCommand(UpdateCmd)
 }

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -116,8 +116,6 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/cli/internal/repo/git.go
+++ b/cli/internal/repo/git.go
@@ -219,7 +219,7 @@ func CommitSubmodule(dir, message, submodule string, verbose bool) error {
 	return nil
 }
 
-func Tag(r *git.Repository, tag, message string, push bool) error {
+func Tag(r *git.Repository, tag string, push bool) error {
 
 	h, err := r.Head()
 	if err != nil {

--- a/cli/internal/repo/repo.go
+++ b/cli/internal/repo/repo.go
@@ -53,7 +53,15 @@ func GetOrg(repo string) (string, error) {
 }
 
 func GetGbmReleasePr(version string) (PullRequest, error) {
-	filter := BuildRepoFilter("gutenberg-mobile", "is:pr", fmt.Sprintf("%s in:title", version))
+	return getReleasePr("gutenberg-mobile", version)
+}
+
+func GetGbReleasePr(version string) (PullRequest, error) {
+	return getReleasePr("gutenberg", version)
+}
+
+func getReleasePr(repo, version string) (PullRequest, error) {
+	filter := BuildRepoFilter(repo, "is:pr", fmt.Sprintf("%s in:title", version))
 
 	res, err := SearchPrs(filter)
 	if err != nil {
@@ -66,5 +74,7 @@ func GetGbmReleasePr(version string) (PullRequest, error) {
 	if res.TotalCount != 1 {
 		return PullRequest{}, fmt.Errorf("found multiple prs for %s", version)
 	}
-	return res.Items[0], nil
+	pr := res.Items[0]
+	pr.Repo = repo
+	return pr, nil
 }

--- a/cli/internal/repo/repo.go
+++ b/cli/internal/repo/repo.go
@@ -74,7 +74,10 @@ func getReleasePr(repo, version string) (PullRequest, error) {
 	if res.TotalCount != 1 {
 		return PullRequest{}, fmt.Errorf("found multiple prs for %s", version)
 	}
-	pr := res.Items[0]
-	pr.Repo = repo
-	return pr, nil
+
+	// The search result is not exactly a PR,
+	// The api only returns partial RP info
+	result := res.Items[0]
+
+	return GetPr(repo, result.Number)
 }

--- a/cli/internal/repo/repo.go
+++ b/cli/internal/repo/repo.go
@@ -57,7 +57,7 @@ func GetGbmReleasePr(version string) (PullRequest, error) {
 }
 
 func GetGbReleasePr(version string) (PullRequest, error) {
-	return getReleasePr("gutenberg", version)
+	return getReleasePr("gutenberg", "v"+version)
 }
 
 func getReleasePr(repo, version string) (PullRequest, error) {

--- a/cli/pkg/gbm/gbm.go
+++ b/cli/pkg/gbm/gbm.go
@@ -134,9 +134,5 @@ func CreatePr(gbmr *git.Repository, pr *repo.PullRequest, verbose bool) error {
 	}
 
 	l("Creating the PR")
-	if err := repo.CreatePr("gutenberg-mobile", pr); err != nil {
-		return err
-	}
-
-	return nil
+	return repo.CreatePr("gutenberg-mobile", pr)
 }

--- a/cli/pkg/gbm/gbm.go
+++ b/cli/pkg/gbm/gbm.go
@@ -1,0 +1,142 @@
+package gbm
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/wordpress-mobile/gbm-cli/internal/exc"
+	"github.com/wordpress-mobile/gbm-cli/internal/repo"
+	"github.com/wordpress-mobile/gbm-cli/internal/utils"
+)
+
+func logger(v bool) func(string, ...interface{}) {
+	return func(f string, a ...interface{}) {
+		if v {
+			utils.LogInfo("\nGBM "+f, a...)
+		}
+	}
+}
+
+func excNpm(dir string, verbose bool) func(cmds ...string) error {
+	return func(cmds ...string) error {
+		return exc.Npm(dir, verbose, cmds...)
+	}
+}
+
+func PrepareBranch(dir string, pr *repo.PullRequest, verbose bool) (*git.Repository, error) {
+	l := logger(verbose)
+
+	gbmDir := filepath.Join(dir, "gutenberg-mobile")
+	npm := excNpm(gbmDir, verbose)
+
+	d := utils.LogDebug
+	version := pr.ReleaseVersion
+	var gbmr *git.Repository
+	var err error
+
+	// If we already have a copy of GBM, initialize the repo
+	// Otherwise clone at pr.Base
+	if _, ok := os.Stat(gbmDir); ok != nil {
+		l("Cloning Gutenberg Mobile")
+		gbmr, err = repo.CloneGBM(gbmDir, verbose)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		l("Initializing Gutenberg Mobile Repo at %s", gbmDir)
+		gbmr, err = repo.Open(gbmDir)
+		if err != nil {
+			return nil, fmt.Errorf("issue opening gutenberg-mobile (err %s)", err)
+		}
+	}
+
+	if err := repo.Switch(gbmDir, pr.Head.Ref, verbose); err != nil {
+		return nil, fmt.Errorf("unable to switch to %s (err %s)", pr.Head.Ref, err)
+	}
+
+	l("Checking Gutenberg")
+	// Check if Gutenberg is porcelain
+	gbr, err := repo.Open(filepath.Join(gbmDir, "gutenberg"))
+	if err != nil {
+		return nil, err
+	}
+	if clean, err := repo.IsPorcelain(gbr); err != nil {
+		return nil, err
+	} else if !clean {
+		return nil, errors.New("gutenberg has some uncommitted changes")
+	}
+
+	l("Updating Gutenberg")
+	if err = repo.CommitSubmodule(gbmDir, "Release script: Updating gutenberg ref", "gutenberg", verbose); err != nil {
+		return nil, fmt.Errorf("failed to update gutenberg: %s", err)
+	}
+
+	l("Set up Node")
+	if err := exc.SetupNode(gbmDir, verbose); err != nil {
+		return nil, fmt.Errorf("failed to update node (err %s)", err)
+	}
+
+	l("Installing npm packages")
+	if err := npm("ci"); err != nil {
+		return nil, fmt.Errorf("failed to update node packages (err %s)", err)
+	}
+
+	l("Update XCFramework builders project Podfile.lock")
+	xcfDir := filepath.Join(gbmDir, "ios-xcframework")
+	if err := exc.BundleInstall(xcfDir, verbose); err != nil {
+		return nil, err
+	}
+	if err := exc.PodInstall(xcfDir, verbose); err != nil {
+		return nil, err
+	}
+	d("about to commit xcf")
+	if err := repo.CommitAll(gbmr, "Release script: Sync XCFramework `Podfile.lock`"); err != nil {
+		return nil, err
+	}
+
+	// If there is a version we should update the package json
+	if version != "" {
+
+		l("Updating the version")
+		if err := npm("--no-git-tag-version", "version", version); err != nil {
+			return nil, err
+		}
+
+		if err := repo.Commit(gbmr, "Update Version", "package.json", "package-lock.json"); err != nil {
+			return nil, err
+		}
+
+	} else {
+		// Otherwise just update the bundle
+		if err := npm("run", "bundle"); err != nil {
+			return nil, err
+		}
+	}
+
+	l("Updating the bundle")
+	if err := repo.CommitAll(gbmr, "Release script: Update bundle for"+version); err != nil {
+		return nil, err
+	}
+
+	return gbmr, nil
+}
+
+func CreatePr(gbmr *git.Repository, pr *repo.PullRequest, verbose bool) error {
+
+	l := logger(verbose)
+
+	l("Pushing the branch")
+	if err := repo.Push(gbmr, verbose); err != nil {
+		return err
+	}
+
+	l("Creating the PR")
+	if err := repo.CreatePr("gutenberg-mobile", pr); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -14,7 +14,7 @@ import (
 
 func CreateGbPR(version, dir string, verbose bool) (repo.PullRequest, error) {
 
-	l := logger(verbose)
+	l := logger()
 	pr := repo.PullRequest{}
 
 	gbBranchName := fmt.Sprintf("rnmobile/release_%s", version)

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -126,19 +126,9 @@ func CreateGbPR(version, dir string, verbose bool) (repo.PullRequest, error) {
 	pr.Base.Ref = "trunk"
 	pr.Head.Ref = gbBranchName
 
-	pd := struct {
-		Version  string
-		GbmPrUrl string
-	}{
-		Version:  version,
-		GbmPrUrl: "",
+	if err := renderGbPrBody(version, "", &pr); err != nil {
+		utils.LogWarn("Unable to render the GB PR body (err %s)", err)
 	}
-
-	body, err := render.Render("templates/release/gbPrBody.md", pd, nil)
-	if err != nil {
-		fmt.Println(err)
-	}
-	pr.Body = body
 
 	pr.Labels = []repo.Label{{
 		Name: "Mobile App - i.e. Android or iOS",
@@ -172,4 +162,21 @@ func CreateGbPR(version, dir string, verbose bool) (repo.PullRequest, error) {
 	}
 
 	return pr, nil
+}
+
+func renderGbPrBody(version, gbmPRUrl string, pr *repo.PullRequest) error {
+	pd := struct {
+		Version  string
+		GbmPrUrl string
+	}{
+		Version:  version,
+		GbmPrUrl: gbmPRUrl,
+	}
+
+	body, err := render.Render("templates/release/gbPrBody.md", pd, nil)
+	if err != nil {
+		return err
+	}
+	pr.Body = body
+	return nil
 }

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -1,0 +1,133 @@
+package release
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/wordpress-mobile/gbm-cli/internal/repo"
+	"github.com/wordpress-mobile/gbm-cli/internal/utils"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
+	"github.com/wordpress-mobile/gbm-cli/pkg/render"
+)
+
+/*
+ This will use internal/gbm/CreateGbmPr to create the PR
+ it will just do the extra release specific stuff
+ like updating the version number an release notes
+
+ It can also post the testing instructions as comments to the PR
+*/
+
+func CreateGbmPr(version, dir string, verbose bool) (repo.PullRequest, error) {
+
+	l := logger(verbose)
+
+	l("\nPreparing Gutenberg Mobile Release PR")
+
+	headBranch := "release/" + version
+	pr := repo.PullRequest{
+		Head:           repo.Repo{Ref: headBranch},
+		Base:           repo.Repo{Ref: "trunk"},
+		Draft:          true,
+		Labels:         []repo.Label{{Name: "release-process"}},
+		ReleaseVersion: version,
+		Title:          "Release " + version,
+		Repo:           "gutenberg-repo",
+	}
+
+	gbmr, err := gbm.PrepareBranch(dir, &pr, verbose)
+	if err != nil {
+		return pr, err
+	}
+
+	renderBody(dir, &pr)
+
+	repo.PreviewPr("gutenberg-mobile", filepath.Join(dir, "gutenberg-mobile"), &pr)
+	org, _ := repo.GetOrg("gutenberg-mobile")
+
+	prompt := fmt.Sprintf("\nReady to create the PR on %s/gutenberg?", org)
+	cont := utils.Confirm(prompt)
+	if !cont {
+		l("Bye 👋")
+		os.Exit(0)
+	}
+
+	if err := gbm.CreatePr(gbmr, &pr, verbose); err != nil {
+		return pr, err
+	}
+
+	return pr, nil
+}
+
+func renderBody(dir string, pr *repo.PullRequest) {
+	version := pr.ReleaseVersion
+
+	// Read in the change log
+	clPath := filepath.Join(dir, "gutenberg-mobile", "gutenberg", "packages", "react-native-editor", "CHANGELOG.md")
+	cl := []byte{}
+	if clf, err := os.Open(clPath); err != nil {
+		utils.LogError("unable to open the change log (err %s)", err)
+	} else {
+		defer clf.Close()
+		if data, err := io.ReadAll(clf); err != nil {
+			utils.LogError("unable to read the change log (err %s)", err)
+		} else {
+			cl = data
+		}
+	}
+
+	// Read in the release notes
+	rnPath := filepath.Join(dir, "gutenberg-mobile", "RELEASE-NOTES.txt")
+	rn := []byte{}
+	if rnf, err := os.Open(rnPath); err != nil {
+		utils.LogError("unable to open the release notes (err %err)", err)
+	} else {
+		defer rnf.Close()
+		if data, err := io.ReadAll(rnf); err != nil {
+			utils.LogError("unable to read the release notes (err %s)", err)
+		} else {
+			rn = data
+		}
+	}
+
+	rc, err := CollectReleaseChanges(version, cl, rn)
+	if err != nil {
+		utils.LogError("unable to collect release changes (err %s)", err)
+	}
+	rfs := []repo.RepoFilter{
+		repo.BuildRepoFilter("gutenberg", "is:open", "is:pr", `label:"Mobile App - i.e. Android or iOS"`),
+		repo.BuildRepoFilter("WordPress-Android", "is:open", "is:pr"),
+		repo.BuildRepoFilter("WordPress-iOS", "is:open", "is:pr"),
+	}
+
+	synced, err := repo.FindGbmSyncedPrs(*pr, rfs)
+	if err != nil {
+		utils.LogError("unable to find synced Prs")
+	}
+
+	prs := []repo.PullRequest{}
+	for _, s := range synced {
+		prs = append(prs, s.Items...)
+	}
+
+	data := struct {
+		Version    string
+		Changes    []ReleaseChanges
+		RelatedPRs []repo.PullRequest
+	}{
+		Version:    version,
+		Changes:    rc,
+		RelatedPRs: prs,
+	}
+
+	body, err := render.Render("templates/release/gbmPrBody.md", data, nil)
+
+	if err != nil {
+		utils.LogError("unable to render the GBM pr body (err %s)", err)
+		pr.Body = "TBD"
+	}
+
+	pr.Body = body
+}

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -42,7 +42,7 @@ func CreateGbmPr(version, dir string, verbose bool) (repo.PullRequest, error) {
 		return pr, err
 	}
 
-	renderBody(dir, &pr)
+	renderGbmBody(dir, &pr)
 
 	repo.PreviewPr("gutenberg-mobile", filepath.Join(dir, "gutenberg-mobile"), &pr)
 	org, _ := repo.GetOrg("gutenberg-mobile")
@@ -78,7 +78,7 @@ func CreateGbmPr(version, dir string, verbose bool) (repo.PullRequest, error) {
 	return pr, nil
 }
 
-func renderBody(dir string, pr *repo.PullRequest) {
+func renderGbmBody(dir string, pr *repo.PullRequest) {
 	version := pr.ReleaseVersion
 
 	// Read in the change log
@@ -114,9 +114,9 @@ func renderBody(dir string, pr *repo.PullRequest) {
 		utils.LogError("unable to collect release changes (err %s)", err)
 	}
 	rfs := []repo.RepoFilter{
-		repo.BuildRepoFilter("gutenberg", "is:open", "is:pr", `label:"Mobile App - i.e. Android or iOS"`),
-		repo.BuildRepoFilter("WordPress-Android", "is:open", "is:pr"),
-		repo.BuildRepoFilter("WordPress-iOS", "is:open", "is:pr"),
+		repo.BuildRepoFilter("gutenberg", "is:open", "is:pr", `label:"Mobile App - i.e. Android or iOS"`, fmt.Sprintf("v%s in:title", version)),
+		repo.BuildRepoFilter("WordPress-Android", "is:open", "is:pr", version+" in:title"),
+		repo.BuildRepoFilter("WordPress-iOS", "is:open", "is:pr", version+" in:title"),
 	}
 
 	synced, err := repo.FindGbmSyncedPrs(*pr, rfs)

--- a/cli/pkg/release/gbm_test.go
+++ b/cli/pkg/release/gbm_test.go
@@ -1,0 +1,1 @@
+package release

--- a/cli/pkg/release/integration.go
+++ b/cli/pkg/release/integration.go
@@ -3,10 +3,12 @@ package release
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 
 	"github.com/wordpress-mobile/gbm-cli/internal/integration"
 	"github.com/wordpress-mobile/gbm-cli/internal/repo"
+	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/render"
 )
 
@@ -16,8 +18,8 @@ func CreateAndroidPr(version, baseBranch, dir string, gbmPr repo.PullRequest, ve
 		Repo:        "WordPress-Android",
 		HeadBranch:  fmt.Sprintf("gutenberg/integrate_release_%s", version),
 		BaseBranch:  baseBranch,
-		RenderTitle: buildTitleRenderer(version),
-		RenderBody:  buildBodyRenderer(version, "templates/release/integrationPrBody.md"),
+		Title:       fmt.Sprintf("Integrate Gutenberg Mobile %s", version),
+		Body:        renderIntegrationBody(version, "templates/release/integrationPrBody.md", gbmPr),
 		Labels:      []repo.Label{{Name: "Gutenberg"}},
 		Draft:       true,
 		Dir:         dir,
@@ -26,7 +28,7 @@ func CreateAndroidPr(version, baseBranch, dir string, gbmPr repo.PullRequest, ve
 		UpdateVersion: buildUpdateAndroidVersion(fmt.Sprintf("%d-%s", gbmPr.Number, gbmPr.Head.Sha)),
 	}
 
-	return integration.CreateIntegrationPr(t, gbmPr, verbose)
+	return createPr(t, gbmPr, verbose)
 }
 
 func CreateIosPr(version, baseBranch, dir string, gbmPr repo.PullRequest, verbose bool) (repo.PullRequest, error) {
@@ -35,8 +37,8 @@ func CreateIosPr(version, baseBranch, dir string, gbmPr repo.PullRequest, verbos
 		Repo:        "WordPress-iOS",
 		HeadBranch:  fmt.Sprintf("gutenberg/integrate_release_%s", version),
 		BaseBranch:  baseBranch,
-		RenderTitle: buildTitleRenderer(version),
-		RenderBody:  buildBodyRenderer(version, "templates/release/integrationPrBody.md"),
+		Title:       fmt.Sprintf("Integrate Gutenberg Mobile %s", version),
+		Body:        renderIntegrationBody(version, "templates/release/integrationPrBody.md", gbmPr),
 		Labels:      []repo.Label{{Name: "Gutenberg"}},
 		Draft:       true,
 		Dir:         dir,
@@ -44,39 +46,50 @@ func CreateIosPr(version, baseBranch, dir string, gbmPr repo.PullRequest, verbos
 		// The initial PR will be created with a commit version
 		UpdateVersion: buildUpdateIosVersion(gbmPr.Head.Sha),
 	}
-
-	return integration.CreateIntegrationPr(t, gbmPr, verbose)
+	return createPr(t, gbmPr, verbose)
 }
 
-// Build a closure around the release version. This is later used to render the PR title.
-// We don't need the gbm PR here, but we need to keep the same signature as the other renderers.
-func buildTitleRenderer(version string) func(repo.PullRequest) string {
-	return func(_ repo.PullRequest) string {
-		return fmt.Sprintf("Integrate Gutenberg Mobile %s", version)
+func createPr(target integration.Target, gbmPr repo.PullRequest, verbose bool) (repo.PullRequest, error) {
+	rpo, err := integration.PrepareBranch(target, gbmPr, verbose)
+	if err != nil {
+		return repo.PullRequest{}, err
 	}
+
+	org, _ := repo.GetOrg(target.Repo)
+	prompt := fmt.Sprintf("\nReady to create the PR on %s/%s?", org, target.Repo)
+	cont := utils.Confirm(prompt)
+	if !cont {
+		utils.LogInfo("Bye 👋")
+		os.Exit(0)
+	}
+
+	pr := repo.PullRequest{
+		Title:  target.Title,
+		Body:   target.Body,
+		Head:   repo.Repo{Ref: target.HeadBranch},
+		Base:   repo.Repo{Ref: target.BaseBranch},
+		Labels: []repo.Label{{Name: "Gutenberg"}},
+		Draft:  true,
+	}
+
+	err = integration.CreatePr(target.Repo, rpo, &pr, verbose)
+	return pr, err
 }
 
-// Build a closure around the release version and template path.
-// This is later used to render the PR body.
-// The template path is passed in to make it easier to test.
-func buildBodyRenderer(version, templatePath string) func(repo.PullRequest) string {
-	return func(gbmPr repo.PullRequest) string {
-
-		data := struct {
-			Version  string
-			GbmPrUrl string
-		}{
-			Version:  version,
-			GbmPrUrl: gbmPr.Url,
-		}
-
-		body, err := render.Render(templatePath, data, nil)
-		if err != nil {
-			fmt.Println(err)
-		}
-		return body
-
+func renderIntegrationBody(version, templatePath string, gbmPr repo.PullRequest) string {
+	data := struct {
+		Version  string
+		GbmPrUrl string
+	}{
+		Version:  version,
+		GbmPrUrl: gbmPr.Url,
 	}
+
+	body, err := render.Render(templatePath, data, nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return body
 }
 
 func buildUpdateAndroidVersion(version string) integration.VersionUpdaterFunc {

--- a/cli/pkg/release/integration_test.go
+++ b/cli/pkg/release/integration_test.go
@@ -1,42 +1,11 @@
 package release
 
 import (
-	"embed"
 	"testing"
 
 	"github.com/andreyvit/diff"
 	"github.com/wordpress-mobile/gbm-cli/internal/repo"
-	"github.com/wordpress-mobile/gbm-cli/pkg/render"
 )
-
-//go:embed testdata/*
-var templatesFS embed.FS
-
-func init() {
-	render.TemplateFS = templatesFS
-}
-
-func TestGenBodyRenderer(t *testing.T) {
-
-	t.Run("Generates a function to render a PR body", func(t *testing.T) {
-		version := "1.2.3"
-		renderBody := buildBodyRenderer(version, "testdata/integrationPrBody.md")
-
-		gbmPr := repo.PullRequest{
-			Url: "https://wordpress.com",
-		}
-
-		want := `## Description
-This PR incorporates the 1.2.3 release of gutenberg-mobile.
-For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://wordpress.com
-`
-		got := renderBody(gbmPr)
-
-		if got != want {
-			t.Fatalf("strings are not equal: %s", diff.LineDiff(got, want))
-		}
-	})
-}
 
 func TestUpdateIosVersion(t *testing.T) {
 

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -15,11 +15,9 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 )
 
-func logger(v bool) func(string, ...interface{}) {
+func logger() func(string, ...interface{}) {
 	return func(f string, a ...interface{}) {
-		if v {
-			utils.LogInfo(f, a...)
-		}
+		utils.LogInfo(f, a...)
 	}
 }
 

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/wordpress-mobile/gbm-cli/internal/repo"
@@ -265,5 +266,127 @@ func getLineRegexp() struct {
 	}{
 		ios:     regexp.MustCompile(`(?m)^.*WordPress-Aztec-iOS.*$`),
 		android: regexp.MustCompile(`(?m)^.*aztecVersion.*$`),
+	}
+}
+
+type ReleaseChanges struct {
+	Title  string
+	Number int
+	PrUrl  string
+	Issues []string
+}
+
+func CollectReleaseChanges(version string, changelog, relnotes []byte) ([]ReleaseChanges, error) {
+	changesRe := regexp.MustCompile(`(?s)\d+\.\d+\.\d+(.*?)\d+\.\d+\.\d+`)
+	// rnChangesRe := regexp.MustCompile(`(?s)\d+\.\d+\.\d+(.*?)\d+\.\d+\.\d+`)
+	prNumbRe := regexp.MustCompile(`\[#(\d+)\]`)
+	prOrgRepoNumRe := regexp.MustCompile(`https://github\.com/(\w+)/(\w+)/pull/(\d+)`)
+	bracketRe := regexp.MustCompile(`\[.*\]\s*-*`)
+
+	prs := []ReleaseChanges{}
+
+	prFoundAlready := func(num int) bool {
+		for _, p := range prs {
+			if p.Number == num {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Get the changes from the Release notes
+	match := changesRe.Find(relnotes)
+	if match != nil {
+
+		lines := strings.Split(string(match), "\n")
+
+		for _, l := range lines {
+			// first check for any prs relative to gutenberg-mobile
+			matches := prNumbRe.FindAllStringSubmatch(l, -1)
+
+			if len(matches) == 1 {
+
+				prId, _ := strconv.Atoi(matches[0][1])
+
+				pr, err := repo.GetPrOrg("WordPress", "gutenberg", prId)
+				if err != nil {
+					utils.LogWarn("There was an issue fetching a gutenberg pr #%d", prId)
+					continue
+				}
+				// Scrub [] from title
+				title := bracketRe.ReplaceAllString(pr.Title, "")
+				prs = append(prs, ReleaseChanges{Title: title, PrUrl: pr.Url, Number: pr.Number})
+			}
+
+			// now look for urls
+			matches = prOrgRepoNumRe.FindAllStringSubmatch(l, -1)
+			if len(matches) != 0 {
+				match := matches[0]
+				org := match[1]
+				rep := match[2]
+				num := match[3]
+				prId, _ := strconv.Atoi(num)
+				pr, err := repo.GetPrOrg(org, rep, prId)
+				if err != nil {
+					utils.LogWarn("There was an issue fetching %s/%s/pull/%d", org, rep, prId)
+					continue
+				}
+				// Scrub [] from title
+				title := bracketRe.ReplaceAllString(pr.Title, "")
+				rc := ReleaseChanges{
+					Title:  title,
+					PrUrl:  pr.Url,
+					Number: pr.Number,
+				}
+				checkPRforIssues(pr, &rc)
+				prs = append(prs, rc)
+			}
+		}
+	}
+	// Get changes from the Change log
+	match = changesRe.Find(changelog)
+
+	if match != nil {
+		lines := strings.Split(string(match), "\n")
+
+		for _, l := range lines {
+
+			match := prNumbRe.FindAllStringSubmatch(l, -1)
+
+			if len(match) == 1 {
+				prId, _ := strconv.Atoi(match[0][1])
+				if prFoundAlready(prId) {
+					continue
+				}
+				pr, err := repo.GetPrOrg("WordPress", "gutenberg", prId)
+				if err != nil {
+					utils.LogWarn("There was an issue fetching a gutenberg pr #%d", prId)
+					continue
+				}
+
+				title := bracketRe.ReplaceAllString(pr.Title, "")
+				rc := ReleaseChanges{
+					Title:  title,
+					PrUrl:  pr.Url,
+					Number: pr.Number,
+				}
+				checkPRforIssues(pr, &rc)
+				prs = append(prs, rc)
+
+			}
+		}
+
+	}
+
+	return prs, nil
+}
+
+func checkPRforIssues(pr repo.PullRequest, rc *ReleaseChanges) {
+	issueRe := regexp.MustCompile(`(https:\/\/github.com\/.*\/.*\/issues\/\d*)`)
+
+	matches := issueRe.FindAllStringSubmatch(pr.Body, -1)
+
+	for _, m := range matches {
+		rc.Issues = append(rc.Issues, m[1])
 	}
 }

--- a/cli/pkg/release/utils_test.go
+++ b/cli/pkg/release/utils_test.go
@@ -104,7 +104,12 @@ For each user feature we should also add a importance categorization label  to i
 ## 1.97.0
 -   [*] [internal] Upgrade compile and target sdk version to Android API 33 [#50731]
 
-## 1.96.1
+## 1.96.0
+-   [**] Tapping on all nested blocks gets focus directly instead of having to tap multiple times depending on the nesting levels. [#50672]
+-   [**] Fix undo/redo history when inserting a link configured to open in a new tab [#50460]
+-   [*] [List block] Fix an issue when merging a list item into a Paragraph would remove its nested list items. [#50701]
+
+## 1.95.0
 -   [**] Fix Android-only issue related to block toolbar not being displayed on some blocks in UBE [#51131]`
 
 		td := readTestdata(t, "testdata/CHANGELOG.md")

--- a/cli/templates/release/gbmPrBody.md
+++ b/cli/templates/release/gbmPrBody.md
@@ -1,0 +1,30 @@
+Release for Gutenberg Mobile {{ .Version }}
+
+## Related PRs
+{{ range .RelatedPRs }}
+- {{ .Url }}{{ end }}
+
+## Changes
+
+{{ range .Changes }}
+### {{ .Title }}
+* PR {{ .PrUrl }}
+{{ range $i, $issue := .Issues }}
+* Issue {{ $i }}{{ $issue }}{{ end }}
+{{ end }}
+
+
+
+<!-- To determine the changes you can check the RELEASE-NOTES.txt and gutenberg/packages/react-native-editor/CHANGELOG.md files and cross check with the list of commits that are part of the PR -->
+
+
+## Test plan
+
+Once the installable builds of the main apps are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing. We will perform additional testing after the main apps cut their releases.
+
+## Release Submission Checklist
+
+- [ ] Verify Items from test plan have been completed
+- [ ] Check if `RELEASE-NOTES.txt` is updated with all the changes that made it to the release. Replace `Unreleased` section with the release version and create a new `Unreleased` section.
+- [ ] Check if `gutenberg/packages/react-native-editor/CHANGELOG.md` is updated with all the changes that made it to the release. Replace `## Unreleased` with the release version and create a new `## Unreleased`.
+- [ ] Bundle package of the release is updated.


### PR DESCRIPTION
This adds a flow to create a GBM PR.  

This adds
`pkg/gbm/gbm.go`  to create a GB linked GBM PR
`pkg/release/gbm.go`  to create a release specific GBM PR

The PR also includes some updates to the `prepare` script to create all release PRs. 
See `go run main.go release prepare -h` to see the relevant flags to create the additional PRs.

Testing:
- Set the env to point to a test Github org
- run `go run main.go release prepare 0.1.0 --gbm --integrate` 
- Wait for prompts to create each of the 4 release PRs.
- Check the GB and GBM PRs to verify that the all release changes are performed and that the PR descriptions are accurate. Note this should fill in all of the GBM release information.
- 

