### PR TITLE
Update to the `release prepare` command

### DIFF
--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -24,10 +24,10 @@ var PrepareCmd = &cobra.Command{
 
 		var err error
 
-		runIntegration := Apps || Android || Ios
+		runAnyIntegration := Android || Ios
 
 		// Before we start let's make sure the someone didn't forget a flag
-		if runIntegration && !Gbm {
+		if runAnyIntegration && !Gbm {
 			cont := utils.Confirm("🤔 You didn't specify --gbm but also included an integration flag. Continuing will only create the Gutenberg PR, are you sure?")
 			if !cont {
 				utils.LogInfo("👋 Bye!")
@@ -35,7 +35,7 @@ var PrepareCmd = &cobra.Command{
 			}
 		}
 
-		if Gbm && runIntegration {
+		if All {
 			utils.LogInfo("📦 Running full release pipeline. Let's go! 🚀")
 		}
 
@@ -48,7 +48,7 @@ var PrepareCmd = &cobra.Command{
 
 		utils.LogInfo("🏁 Gutenberg release ready to go, check it out: %s", gbpr.Url)
 
-		if Gbm {
+		if Gbm || All {
 			gbmpr, _ := release.CreateGbmPr(version, TempDir, !Quite)
 
 			results = append(results, releaseResult{
@@ -58,11 +58,12 @@ var PrepareCmd = &cobra.Command{
 			})
 
 			utils.LogInfo("🏁 Gutenberg Mobile release ready to go, check it out: %s", gbmpr.Url)
-		}
 
-		if Gbm && runIntegration {
-			intResults := integrate(version)
-			results = append(results, intResults...)
+			// Run the integrations if we are preparing all or any integration PRs
+			if All || runAnyIntegration {
+				intResults := integrate(version)
+				results = append(results, intResults...)
+			}
 		}
 
 		for _, r := range results {
@@ -78,9 +79,9 @@ var PrepareCmd = &cobra.Command{
 }
 
 func init() {
-	PrepareCmd.Flags().BoolVarP(&Gbm, "gbm", "", false, "prepare gutenberg mobile pr")
-	PrepareCmd.Flags().BoolVarP(&Apps, "integrate", "", false, "prepare ios and android prs")
-	PrepareCmd.Flags().BoolVarP(&Android, "android", "", false, "prepare android pr")
-	PrepareCmd.Flags().BoolVarP(&Ios, "ios", "", false, "prepare ios pr")
+	PrepareCmd.Flags().BoolVarP(&Gbm, "gbm", "", false, "prepare gutenberg mobile PR")
+	PrepareCmd.Flags().BoolVarP(&All, "all", "", false, "prepare all release PRs")
+	PrepareCmd.Flags().BoolVarP(&Android, "android", "", false, "prepare android PR - requires --gbm")
+	PrepareCmd.Flags().BoolVarP(&Ios, "ios", "", false, "prepare ios pr - requires --gbm")
 	PrepareCmd.Flags().BoolVarP(&Quite, "quite", "q", false, "silence output")
 }

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -39,7 +39,7 @@ var PrepareCmd = &cobra.Command{
 			utils.LogInfo("📦 Running full release pipeline. Let's go! 🚀")
 		}
 
-		gbpr, err := release.CreateGbPR(version, TempDir, Verbose)
+		gbpr, err := release.CreateGbPR(version, TempDir, !Quite)
 		results = append(results, releaseResult{
 			pr:   gbpr,
 			err:  err,
@@ -49,7 +49,7 @@ var PrepareCmd = &cobra.Command{
 		utils.LogInfo("🏁 Gutenberg release ready to go, check it out: %s", gbpr.Url)
 
 		if Gbm {
-			gbmpr, _ := release.CreateGbmPr(version, TempDir, Verbose)
+			gbmpr, _ := release.CreateGbmPr(version, TempDir, !Quite)
 
 			results = append(results, releaseResult{
 				pr:   gbmpr,
@@ -82,5 +82,5 @@ func init() {
 	PrepareCmd.Flags().BoolVarP(&Apps, "integrate", "", false, "prepare ios and android prs")
 	PrepareCmd.Flags().BoolVarP(&Android, "android", "", false, "prepare android pr")
 	PrepareCmd.Flags().BoolVarP(&Ios, "ios", "", false, "prepare ios pr")
-	PrepareCmd.Flags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	PrepareCmd.Flags().BoolVarP(&Quite, "quite", "q", false, "silence output")
 }

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -24,8 +24,8 @@ var (
 	BaseBranch string
 
 	// Used by `prepare`
-	Gbm  bool
-	Apps bool
+	Gbm bool
+	All bool
 )
 
 type releaseResult struct {
@@ -47,7 +47,7 @@ func init() {
 	go func() {
 		<-c
 		cleanup()
-		os.Exit(1)
+		os.Exit(0)
 	}()
 }
 

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -13,6 +13,7 @@ import (
 var (
 	TempDir string
 	Verbose bool
+	Quite   bool
 
 	// Used by `integrate` and `prepare`
 	Ios     bool
@@ -76,5 +77,4 @@ func init() {
 	RootCmd.AddCommand(PrepareCmd)
 	RootCmd.AddCommand(IntegrateCmd)
 	RootCmd.AddCommand(StatusCmd)
-	RootCmd.AddCommand(UpdateCmd)
 }

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -156,11 +156,12 @@ func CreateGbPR(version, dir string, verbose bool) (repo.PullRequest, error) {
 		return pr, fmt.Errorf("unable to create the pr")
 	}
 
-	l("Pushing the release tag")
-	if err := repo.Tag(gbr, fmt.Sprint("rnmobile/", version), fmt.Sprint("Mobile Release v", version), true); err != nil {
-		utils.LogWarn("Unable to push the release tag: %s", err)
-	}
-
+	/*
+		l("Pushing the release tag")
+		if err := repo.Tag(gbr, fmt.Sprint("rnmobile/", version), fmt.Sprint("Mobile Release v", version), true); err != nil {
+			utils.LogWarn("Unable to push the release tag: %s", err)
+		}
+	*/
 	return pr, nil
 }
 


### PR DESCRIPTION
This updates the prepare command with the following

- Remove the `integration` flag and adds a `all` flag to run all release PRs ( the single platform flags are still available)
- Switch to using a `quite` flag vs `verbose`. The default should be noisy.
- Holds off on tagging the gb release PR. Tagging will happen during the publish step.