### PR TITLE
Add release update command

### DIFF
--- a/cli/cmd/release/integrate.go
+++ b/cli/cmd/release/integrate.go
@@ -18,7 +18,7 @@ var IntegrateCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		version := args[0]
+		version := normalizeVersion(args[0])
 
 		results := integrate(version)
 

--- a/cli/cmd/release/integrate.go
+++ b/cli/cmd/release/integrate.go
@@ -43,7 +43,7 @@ func init() {
 
 func integrate(version string) (results []releaseResult) {
 
-	gbmPr, err := repo.GetGbmReleasePr(version)
+	gbmPr, err := release.GetGbmReleasePr(version)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -69,7 +69,7 @@ func integrate(version string) (results []releaseResult) {
 		numPr++
 		utils.LogInfo("Creating iOS PR at %s/Wordpress-iOS", repo.WpMobileOrg)
 		go func() {
-			pr, err := release.CreateIosPr(version, BaseBranch, TempDir, gbmPr, Verbose)
+			pr, err := release.CreateIosPr(version, BaseBranch, TempDir, *gbmPr, Verbose)
 			rChan <- releaseResult{"WordPress-iOS", pr, err}
 		}()
 	}
@@ -78,7 +78,7 @@ func integrate(version string) (results []releaseResult) {
 		numPr++
 		utils.LogInfo("Creating Android PR at %s/WordPress-Android", repo.WpMobileOrg)
 		go func() {
-			pr, err := release.CreateAndroidPr(version, BaseBranch, TempDir, gbmPr, Verbose)
+			pr, err := release.CreateAndroidPr(version, BaseBranch, TempDir, *gbmPr, Verbose)
 			rChan <- releaseResult{"WordPress-Android", pr, err}
 		}()
 	}

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -49,6 +49,7 @@ var PrepareCmd = &cobra.Command{
 		utils.LogInfo("🏁 Gutenberg release ready to go, check it out: %s", gbpr.Url)
 
 		if Gbm || All {
+
 			gbmpr, _ := release.CreateGbmPr(version, TempDir, !Quite)
 
 			results = append(results, releaseResult{
@@ -61,8 +62,10 @@ var PrepareCmd = &cobra.Command{
 
 			// Run the integrations if we are preparing all or any integration PRs
 			if All || runAnyIntegration {
-				intResults := integrate(version)
-				results = append(results, intResults...)
+				if cont := utils.Confirm("Ready to create the integration PRs?"); cont {
+					intResults := integrate(version)
+					results = append(results, intResults...)
+				}
 			}
 		}
 

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -50,7 +50,12 @@ var PrepareCmd = &cobra.Command{
 
 		if Gbm || All {
 
-			gbmpr, _ := release.CreateGbmPr(version, TempDir, !Quite)
+			gbmpr, err := release.CreateGbmPr(version, TempDir, !Quite)
+
+			if err != nil {
+				utils.LogError("Error creating gbm PR: %s", err)
+				os.Exit(1)
+			}
 
 			results = append(results, releaseResult{
 				pr:   gbmpr,

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -19,6 +19,7 @@ var PrepareCmd = &cobra.Command{
 		version := normalizeVersion(args[0])
 
 		setTempDir()
+		defer cleanup()
 
 		results := []releaseResult{}
 

--- a/cli/cmd/release/prepare.go
+++ b/cli/cmd/release/prepare.go
@@ -16,7 +16,7 @@ var PrepareCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		version := args[0]
+		version := normalizeVersion(args[0])
 
 		setTempDir()
 

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"regexp"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -57,6 +58,20 @@ func setTempDir() {
 		fmt.Println("Error creating temp dir")
 		os.Exit(1)
 	}
+}
+
+func normalizeVersion(version string) string {
+	v := version
+	if version[0] == 'v' {
+		v = version[1:]
+	}
+
+	re := regexp.MustCompile(`\d+\.\d+\.\d+`)
+	if !re.MatchString(v) {
+		fmt.Println("Invalid version")
+		os.Exit(1)
+	}
+	return v
 }
 
 // renderCmd represents the render command

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -92,4 +92,5 @@ func init() {
 	RootCmd.AddCommand(PrepareCmd)
 	RootCmd.AddCommand(IntegrateCmd)
 	RootCmd.AddCommand(StatusCmd)
+	RootCmd.AddCommand(UpdateCmd)
 }

--- a/cli/cmd/release/status.go
+++ b/cli/cmd/release/status.go
@@ -19,7 +19,7 @@ var StatusCmd = &cobra.Command{
 	`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		version := args[0]
+		version := normalizeVersion(args[0])
 		gbmPr, err := repo.GetGbmReleasePr(version)
 		if err != nil {
 			utils.LogError("%v", err)

--- a/cli/cmd/release/status.go
+++ b/cli/cmd/release/status.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/internal/repo"
 	"github.com/wordpress-mobile/gbm-cli/internal/utils"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 )
 
 // renderCmd represents the render command
@@ -20,7 +21,7 @@ var StatusCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		version := normalizeVersion(args[0])
-		gbmPr, err := repo.GetGbmReleasePr(version)
+		gbmPr, err := release.GetGbmReleasePr(version)
 		if err != nil {
 			utils.LogError("%v", err)
 			os.Exit(1)
@@ -32,7 +33,7 @@ var StatusCmd = &cobra.Command{
 			repo.BuildRepoFilter("WordPress-Android", "is:open", "is:pr"),
 			repo.BuildRepoFilter("WordPress-iOS", "is:open", "is:pr"),
 		}
-		results, err := repo.FindGbmSyncedPrs(gbmPr, rfs)
+		results, err := repo.FindGbmSyncedPrs(*gbmPr, rfs)
 
 		if err != nil {
 			utils.LogError("%v", err)
@@ -47,7 +48,7 @@ var StatusCmd = &cobra.Command{
 		gray := color.New(color.FgHiBlack).SprintFunc()
 
 		renderRow(t, cyan("Repo"), cyan("PR"), cyan("State"), cyan("Draft"), cyan("Mergeable"))
-		renderRow(t, "gutenberg-mobile", gbmPr.Url, gbmPr.State, draftStr(gbmPr), mergeableStr(gbmPr))
+		renderRow(t, "gutenberg-mobile", gbmPr.Url, gbmPr.State, draftStr(*gbmPr), mergeableStr(*gbmPr))
 
 		// Render results in a table
 		for _, res := range results {

--- a/cli/cmd/release/update.go
+++ b/cli/cmd/release/update.go
@@ -1,0 +1,43 @@
+package release
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/internal/utils"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
+)
+
+var UpdateCmd = &cobra.Command{
+	Use:   "update <version>",
+	Short: "Update the Gutenberg and Gutenberg Mobile release PRs",
+	Long: `
+  `,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		version := normalizeVersion(args[0])
+		setTempDir()
+
+		utils.LogInfo("Checking if the Gutenberg Mobile PR is current")
+		gbmCurrent := release.IsGbmPrCurrent(version)
+
+		if !gbmCurrent {
+			utils.LogInfo("🚨 The Gutenberg Mobile PR is not current, updating Gutenberg")
+			utils.LogDebug("Updating Gutenberg is not yet implemented")
+			os.Exit(1)
+		} else {
+			utils.LogInfo("The Gutenberg Mobile PR is current")
+		}
+		fmt.Println()
+
+		if gbmCurrent {
+			utils.LogInfo("Both Release PRs are current, nothing to do!")
+			os.Exit(0)
+		}
+	},
+}
+
+func init() {
+	UpdateCmd.Flags().BoolVarP(&Quite, "quite", "q", false, "slience output")
+}

--- a/cli/cmd/release/update.go
+++ b/cli/cmd/release/update.go
@@ -1,7 +1,6 @@
 package release
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -17,27 +16,30 @@ var UpdateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		version := normalizeVersion(args[0])
-		setTempDir()
+
+		// TODO: Might need to make sure the preios step is current on Gutenberg
 
 		utils.LogInfo("Checking if the Gutenberg Mobile PR is current")
 		gbmCurrent := release.IsGbmPrCurrent(version)
 
 		if !gbmCurrent {
 			utils.LogInfo("🚨 The Gutenberg Mobile PR is not current, updating Gutenberg")
-			utils.LogDebug("Updating Gutenberg is not yet implemented")
-			os.Exit(1)
+			setTempDir()
+			defer cleanup()
+			utils.LogDebug("Directory: %s", TempDir)
+			if gbPr, err := release.UpdateGbmPr(version, TempDir, true); err != nil {
+				utils.LogError("Error updating gbm PR: %s", err)
+				os.Exit(1)
+			} else {
+				utils.LogInfo("🏁 Gutenberg Mobile release updated, check it out: %s", gbPr.Url)
+			}
+
 		} else {
 			utils.LogInfo("The Gutenberg Mobile PR is current")
-		}
-		fmt.Println()
-
-		if gbmCurrent {
-			utils.LogInfo("Both Release PRs are current, nothing to do!")
-			os.Exit(0)
 		}
 	},
 }
 
 func init() {
-	UpdateCmd.Flags().BoolVarP(&Quite, "quite", "q", false, "slience output")
+	UpdateCmd.Flags().BoolVarP(&Quite, "quite", "q", false, "silence output")
 }

--- a/cli/internal/repo/gh.go
+++ b/cli/internal/repo/gh.go
@@ -124,30 +124,30 @@ type GhContents struct {
 }
 
 // GetPr returns a PullRequest struct for the given repo and PR number.
-func GetPr(repo string, id int) (PullRequest, error) {
+func GetPr(repo string, id int) (*PullRequest, error) {
 	org, err := GetOrg(repo)
 	if err != nil {
-		return PullRequest{}, err
+		return nil, err
 	}
 	return GetPrOrg(org, repo, id)
 }
 
-func GetPrOrg(org, repo string, id int) (PullRequest, error) {
+func GetPrOrg(org, repo string, id int) (*PullRequest, error) {
 	client := getClient()
 
 	endpoint := fmt.Sprintf("repos/%s/%s/pulls/%d", org, repo, id)
-	response := PullRequest{}
-	if err := client.Get(endpoint, &response); err != nil {
-		return PullRequest{}, err
+	pr := &PullRequest{}
+	if err := client.Get(endpoint, pr); err != nil {
+		return nil, err
 	}
 
-	if response.Number == 0 {
-		return PullRequest{}, fmt.Errorf("pr not found %s", endpoint)
+	if pr.Number == 0 {
+		return nil, fmt.Errorf("pr not found %s", endpoint)
 	}
 
-	response.Repo = repo
+	pr.Repo = repo
 
-	return response, nil
+	return pr, nil
 }
 
 func PreviewPr(repo, dir string, pr *PullRequest) {

--- a/cli/internal/repo/gh.go
+++ b/cli/internal/repo/gh.go
@@ -451,10 +451,10 @@ func labelRequest(repo string, prNum int, labels []string) ([]Label, error) {
 func getOrgRepo(pr *PullRequest) (org string, repo string, err error) {
 
 	if repo = pr.Repo; repo == "" {
-		return "", "", errors.New("Pr is missing a repo")
+		return "", "", errors.New("pr is missing a repo")
 	}
 	if org, err = GetOrg(repo); err != nil {
-		return "", "", fmt.Errorf("Unable to determine the org for the %s repo", repo)
+		return "", "", fmt.Errorf("unable to determine the org for the %s repo", repo)
 	}
 	return org, repo, nil
 }

--- a/cli/internal/repo/gh.go
+++ b/cli/internal/repo/gh.go
@@ -116,6 +116,13 @@ func IsExistingBranchError(err error) bool {
 	return err.(*BranchError).Type == "exists"
 }
 
+type GhContents struct {
+	Name string
+	Sha  string
+	Type string
+	Url  string
+}
+
 // GetPr returns a PullRequest struct for the given repo and PR number.
 func GetPr(repo string, id int) (PullRequest, error) {
 	org, err := GetOrg(repo)
@@ -376,6 +383,20 @@ func GetPrStatus(pr *PullRequest) (RefStatus, error) {
 	}
 
 	return fs, nil
+}
+
+func GetContents(repo, file, branch string) (GhContents, error) {
+	org, err := GetOrg(repo)
+	if err != nil {
+		return GhContents{}, err
+	}
+	client := getClient()
+	endpoint := fmt.Sprintf("repos/%s/%s/contents/%s?ref=%s", org, repo, file, branch)
+	response := GhContents{}
+	if err := client.Get(endpoint, &response); err != nil {
+		return GhContents{}, err
+	}
+	return response, nil
 }
 
 // getClient returns a REST client for the GitHub API.

--- a/cli/internal/repo/gh_test.go
+++ b/cli/internal/repo/gh_test.go
@@ -204,11 +204,7 @@ func TestUpdatePR(t *testing.T) {
 			JSON(labels)
 		defer gock.Off()
 
-		update := PrUpdate{
-			Title: "Updated TEST PR",
-		}
-
-		err := UpdatePr(&pr, update)
+		err := UpdatePr(&pr)
 		assertNoError(t, err)
 		assertEqual(t, pr, want)
 	})
@@ -231,11 +227,7 @@ func TestUpdatePR(t *testing.T) {
 			JSON(string(resp))
 		defer gock.Off()
 
-		update := PrUpdate{
-			Title: "Updated TEST PR",
-		}
-
-		err := UpdatePr(&pr, update)
+		err := UpdatePr(&pr)
 		assertNoError(t, err)
 		assertEqual(t, pr, want)
 	})

--- a/cli/internal/repo/git.go
+++ b/cli/internal/repo/git.go
@@ -85,6 +85,7 @@ func CloneGBM(dir string, pr PullRequest, verbose bool) (*git.Repository, error)
 
 	cmd := []string{"clone", "--recurse-submodules", "--depth", "1"}
 
+	fmt.Println("Checking remote branch...")
 	// check to see if the remote branch exists
 	if err := git("ls-remote", "--exit-code", "--heads", url, pr.Head.Ref); err != nil {
 		cmd = append(cmd, url)
@@ -98,9 +99,11 @@ func CloneGBM(dir string, pr PullRequest, verbose bool) (*git.Repository, error)
 	return Open(filepath.Join(dir, "gutenberg-mobile"))
 }
 
-func Switch(dir, branch string, create, verbose bool) error {
+func Switch(dir, repo, branch string, verbose bool) error {
 
 	git := execGit(dir, verbose)
+
+	create := !remoteExists(dir, repo, branch, verbose)
 
 	if create {
 		return git("switch", "-c", branch)
@@ -117,6 +120,17 @@ func Switch(dir, branch string, create, verbose bool) error {
 	}
 
 	return git("switch", branch)
+}
+
+func remoteExists(dir, repo, ref string, verbose bool) bool {
+	git := execGit(dir, verbose)
+
+	org, _ := GetOrg("gutenberg-mobile")
+	url := fmt.Sprintf("git@github.com:%s/%s.git", org, "gutenberg-mobile")
+	if err := git("ls-remote", "--exit-code", "--heads", url, ref); err != nil {
+		return false
+	}
+	return true
 }
 
 func Checkout(r *git.Repository, branch string) error {

--- a/cli/internal/repo/git.go
+++ b/cli/internal/repo/git.go
@@ -98,20 +98,25 @@ func CloneGBM(dir string, pr PullRequest, verbose bool) (*git.Repository, error)
 	return Open(filepath.Join(dir, "gutenberg-mobile"))
 }
 
-func SubmoduleInit(dir string, verbose bool) error {
+func Switch(dir, branch string, create, verbose bool) error {
+
 	git := execGit(dir, verbose)
 
-	if err := git("submodule", "update", "--init"); err != nil {
-		return fmt.Errorf("submodule update failed (err %s)", err)
+	if create {
+		return git("switch", "-c", branch)
 	}
-	return nil
-}
 
-func Switch(dir, branch string, verbose bool) error {
+	// We do shallow checkouts so we need to fetch the branch
+	err := git("remote", "set-branches", "origin", branch)
+	if err != nil {
+		return fmt.Errorf("unable to set remote branches (err %s)", err)
+	}
+	err = git("fetch", "origin", "--depth", "1")
+	if err != nil {
+		return fmt.Errorf("unable to fetch branch (err %s)", err)
+	}
 
-	git := execGit(dir, verbose)
-
-	return git("switch", "-c", branch)
+	return git("switch", branch)
 }
 
 func Checkout(r *git.Repository, branch string) error {

--- a/cli/internal/repo/repo.go
+++ b/cli/internal/repo/repo.go
@@ -51,33 +51,3 @@ func GetOrg(repo string) (string, error) {
 		return "", fmt.Errorf("unknown repo: %s", repo)
 	}
 }
-
-func GetGbmReleasePr(version string) (PullRequest, error) {
-	return getReleasePr("gutenberg-mobile", version)
-}
-
-func GetGbReleasePr(version string) (PullRequest, error) {
-	return getReleasePr("gutenberg", "v"+version)
-}
-
-func getReleasePr(repo, version string) (PullRequest, error) {
-	filter := BuildRepoFilter(repo, "is:pr", fmt.Sprintf("%s in:title", version))
-
-	res, err := SearchPrs(filter)
-	if err != nil {
-		return PullRequest{}, nil
-	}
-
-	if res.TotalCount == 0 {
-		return PullRequest{}, fmt.Errorf("no release PRs found for `%s`", version)
-	}
-	if res.TotalCount != 1 {
-		return PullRequest{}, fmt.Errorf("found multiple prs for %s", version)
-	}
-
-	// The search result is not exactly a PR,
-	// The api only returns partial RP info
-	result := res.Items[0]
-
-	return GetPr(repo, result.Number)
-}

--- a/cli/pkg/gbm/gbm.go
+++ b/cli/pkg/gbm/gbm.go
@@ -47,6 +47,10 @@ func PrepareBranch(dir string, pr *repo.PullRequest, gbPr *repo.PullRequest, ver
 			return nil, fmt.Errorf("issue opening gutenberg-mobile (err %s)", err)
 		}
 	}
+
+	if err := repo.Switch(gbmDir, "gutenberg-mobile", pr.Head.Ref, verbose); err != nil {
+		return nil, err
+	}
 	// Set up GB
 	if err := setupGb(gbmDir, gbmr, gbPr, verbose); err != nil {
 		return nil, err
@@ -113,7 +117,7 @@ func setupGb(gbmDir string, gbmr *git.Repository, gbPr *repo.PullRequest, verbos
 	if curr, err := repo.IsSubmoduleCurrent(gb, gbPr.Head.Sha); err != nil {
 		return fmt.Errorf("issue checking the submodule (err %s)", err)
 	} else if !curr {
-		if err := repo.Switch(filepath.Join(gbmDir, "gutenberg"), gbPr.Head.Ref, false, verbose); err != nil {
+		if err := repo.Switch(filepath.Join(gbmDir, "gutenberg"), "gutenberg", gbPr.Head.Ref, verbose); err != nil {
 			return fmt.Errorf("unable to switch to %s (err %s)", gbPr.Head.Ref, err)
 		}
 	}
@@ -130,6 +134,7 @@ func setupGb(gbmDir string, gbmr *git.Repository, gbPr *repo.PullRequest, verbos
 
 func CreatePr(gbmr *git.Repository, pr *repo.PullRequest, verbose bool) error {
 
+	// TODO: make sure we are not on trunk before pushing
 	l("Pushing the branch")
 	if err := repo.Push(gbmr, verbose); err != nil {
 		return err

--- a/cli/pkg/gbm/gbm.go
+++ b/cli/pkg/gbm/gbm.go
@@ -1,7 +1,6 @@
 package gbm
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,12 +11,8 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 )
 
-func logger(v bool) func(string, ...interface{}) {
-	return func(f string, a ...interface{}) {
-		if v {
-			utils.LogInfo("\nGBM "+f, a...)
-		}
-	}
+func l(f string, a ...interface{}) {
+	utils.LogInfo("\nGBM "+f, a...)
 }
 
 func excNpm(dir string, verbose bool) func(cmds ...string) error {
@@ -26,22 +21,22 @@ func excNpm(dir string, verbose bool) func(cmds ...string) error {
 	}
 }
 
-func PrepareBranch(dir string, pr *repo.PullRequest, verbose bool) (*git.Repository, error) {
-	l := logger(verbose)
+func PrepareBranch(dir string, pr *repo.PullRequest, gbPr *repo.PullRequest, verbose bool) (*git.Repository, error) {
 
 	gbmDir := filepath.Join(dir, "gutenberg-mobile")
 	npm := excNpm(gbmDir, verbose)
 
-	d := utils.LogDebug
 	version := pr.ReleaseVersion
-	var gbmr *git.Repository
-	var err error
-
+	var (
+		gbmr *git.Repository
+		err  error
+	)
 	// If we already have a copy of GBM, initialize the repo
 	// Otherwise clone at pr.Base
 	if _, ok := os.Stat(gbmDir); ok != nil {
+		os.MkdirAll(gbmDir, os.ModePerm)
 		l("Cloning Gutenberg Mobile")
-		gbmr, err = repo.CloneGBM(gbmDir, verbose)
+		gbmr, err = repo.CloneGBM(dir, *pr, verbose)
 		if err != nil {
 			return nil, err
 		}
@@ -52,26 +47,9 @@ func PrepareBranch(dir string, pr *repo.PullRequest, verbose bool) (*git.Reposit
 			return nil, fmt.Errorf("issue opening gutenberg-mobile (err %s)", err)
 		}
 	}
-
-	if err := repo.Switch(gbmDir, pr.Head.Ref, verbose); err != nil {
-		return nil, fmt.Errorf("unable to switch to %s (err %s)", pr.Head.Ref, err)
-	}
-
-	l("Checking Gutenberg")
-	// Check if Gutenberg is porcelain
-	gbr, err := repo.Open(filepath.Join(gbmDir, "gutenberg"))
-	if err != nil {
+	// Set up GB
+	if err := setupGb(gbmDir, gbmr, gbPr, verbose); err != nil {
 		return nil, err
-	}
-	if clean, err := repo.IsPorcelain(gbr); err != nil {
-		return nil, err
-	} else if !clean {
-		return nil, errors.New("gutenberg has some uncommitted changes")
-	}
-
-	l("Updating Gutenberg")
-	if err = repo.CommitSubmodule(gbmDir, "Release script: Updating gutenberg ref", "gutenberg", verbose); err != nil {
-		return nil, fmt.Errorf("failed to update gutenberg: %s", err)
 	}
 
 	l("Set up Node")
@@ -92,7 +70,7 @@ func PrepareBranch(dir string, pr *repo.PullRequest, verbose bool) (*git.Reposit
 	if err := exc.PodInstall(xcfDir, verbose); err != nil {
 		return nil, err
 	}
-	d("about to commit xcf")
+
 	if err := repo.CommitAll(gbmr, "Release script: Sync XCFramework `Podfile.lock`"); err != nil {
 		return nil, err
 	}
@@ -117,16 +95,40 @@ func PrepareBranch(dir string, pr *repo.PullRequest, verbose bool) (*git.Reposit
 	}
 
 	l("Updating the bundle")
-	if err := repo.CommitAll(gbmr, "Release script: Update bundle for"+version); err != nil {
+	if err := repo.CommitAll(gbmr, "Release script: Update bundle for "+version); err != nil {
 		return nil, err
 	}
 
 	return gbmr, nil
 }
 
-func CreatePr(gbmr *git.Repository, pr *repo.PullRequest, verbose bool) error {
+func setupGb(gbmDir string, gbmr *git.Repository, gbPr *repo.PullRequest, verbose bool) error {
 
-	l := logger(verbose)
+	l("Checking Gutenberg")
+
+	gb, err := repo.GetSubmodule(gbmr, "gutenberg")
+	if err != nil {
+		return err
+	}
+	if curr, err := repo.IsSubmoduleCurrent(gb, gbPr.Head.Sha); err != nil {
+		return fmt.Errorf("issue checking the submodule (err %s)", err)
+	} else if !curr {
+		if err := repo.Switch(filepath.Join(gbmDir, "gutenberg"), gbPr.Head.Ref, false, verbose); err != nil {
+			return fmt.Errorf("unable to switch to %s (err %s)", gbPr.Head.Ref, err)
+		}
+	}
+
+	l("Updating Gutenberg")
+	if clean, _ := repo.IsPorcelain(gbmr); !clean {
+		if err = repo.CommitSubmodule(gbmDir, "Release script: Updating gutenberg ref", "gutenberg", verbose); err != nil {
+			return fmt.Errorf("failed to update gutenberg: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func CreatePr(gbmr *git.Repository, pr *repo.PullRequest, verbose bool) error {
 
 	l("Pushing the branch")
 	if err := repo.Push(gbmr, verbose); err != nil {

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -13,8 +13,6 @@ import (
 )
 
 func CreateGbPR(version, dir string, verbose bool) (repo.PullRequest, error) {
-
-	l := logger()
 	pr := repo.PullRequest{}
 
 	gbBranchName := fmt.Sprintf("rnmobile/release_%s", version)

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -26,14 +26,18 @@ func CreateGbPR(version, dir string, verbose bool) (repo.PullRequest, error) {
 
 	if (existing != repo.Branch{}) {
 		l("Branch %s already exists", gbBranchName)
-		return pr, &repo.BranchError{Err: errors.New("branch already exists"), Type: "exists"}
+		pr, err := GetGbReleasePr(version)
+		if err != nil {
+			utils.LogWarn("Unable to get the GB release PR (err %s)", err)
+		}
+		return *pr, &repo.BranchError{Err: errors.New("branch already exists"), Type: "exists"}
 	}
 
 	gbmDir := filepath.Join(dir, "gutenberg-mobile")
 	gbDir := filepath.Join(gbmDir, "gutenberg")
 
 	l("Cloning GBM repo to %s", gbmDir)
-	_, err := repo.CloneGBM(dir, verbose)
+	_, err := repo.CloneGBM(dir, pr, verbose)
 	if err != nil {
 
 		return pr, err

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -146,6 +146,8 @@ func CreateGbPR(version, dir string, verbose bool) (repo.PullRequest, error) {
 		os.Exit(0)
 	}
 
+	// TODO: Warn if the submodule remote is not set to the script config
+	// Right now it will use what ever is in the Gutenberg Mobile gitmodules file
 	l("Creating the PR")
 	if err := repo.Push(gbr, verbose); err != nil {
 		return pr, err

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -37,7 +37,11 @@ func CreateGbmPr(version, dir string, verbose bool) (repo.PullRequest, error) {
 		Repo:           "gutenberg-repo",
 	}
 
-	gbmr, err := gbm.PrepareBranch(dir, &pr, verbose)
+	gbPr, err := GetGbReleasePr(version)
+	if err != nil {
+		return pr, fmt.Errorf("unable to get the GB release PR (err %s)", err)
+	}
+	gbmr, err := gbm.PrepareBranch(dir, &pr, gbPr, verbose)
 	if err != nil {
 		return pr, err
 	}
@@ -59,16 +63,11 @@ func CreateGbmPr(version, dir string, verbose bool) (repo.PullRequest, error) {
 	}
 
 	// Update the gb release pr
-	gbPr, err := repo.GetGbReleasePr(version)
-	if err != nil {
-		utils.LogWarn("Couldn't get the GB release PR (err %s)", err)
-	}
-
-	if err := renderGbPrBody(version, pr.Url, &gbPr); err != nil {
+	if err := renderGbPrBody(version, pr.Url, gbPr); err != nil {
 		utils.LogWarn("unable to render the GB Pr body to update (err %s)", err)
 	}
 
-	if err := repo.UpdatePr(&gbPr); err != nil {
+	if err := repo.UpdatePr(gbPr); err != nil {
 		utils.LogWarn("unable to update the GB release pr (err %s)", err)
 	}
 

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -67,11 +67,8 @@ func CreateGbmPr(version, dir string, verbose bool) (repo.PullRequest, error) {
 	if err := renderGbPrBody(version, pr.Url, &gbPr); err != nil {
 		utils.LogWarn("unable to render the GB Pr body to update (err %s)", err)
 	}
-	prUp := repo.PrUpdate{
-		Body: pr.Body,
-	}
 
-	if err := repo.UpdatePr(&gbPr, prUp); err != nil {
+	if err := repo.UpdatePr(&gbPr); err != nil {
 		utils.LogWarn("unable to update the GB release pr (err %s)", err)
 	}
 

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -44,6 +44,15 @@ func CreateGbmPr(version, dir string, verbose bool) (repo.PullRequest, error) {
 		return pr, err
 	}
 
+	l("Update the release notes")
+	rnPath := filepath.Join(dir, "gutenberg-mobile", "RELEASE-NOTES.txt")
+	if err := UpdateReleaseNotes(version, rnPath); err != nil {
+		return pr, err
+	}
+	if err := repo.CommitAll(gbmr, fmt.Sprintf("Release script: Update release notes for version %s", version)); err != nil {
+		return pr, err
+	}
+
 	renderGbmBody(dir, &pr)
 
 	repo.PreviewPr("gutenberg-mobile", filepath.Join(dir, "gutenberg-mobile"), &pr)

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -21,9 +21,6 @@ import (
 */
 
 func CreateGbmPr(version, dir string, verbose bool) (repo.PullRequest, error) {
-
-	l := logger()
-
 	l("\nPreparing Gutenberg Mobile Release PR")
 
 	headBranch := "release/" + version

--- a/cli/pkg/release/integration.go
+++ b/cli/pkg/release/integration.go
@@ -3,12 +3,10 @@ package release
 import (
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 
 	"github.com/wordpress-mobile/gbm-cli/internal/integration"
 	"github.com/wordpress-mobile/gbm-cli/internal/repo"
-	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/render"
 )
 
@@ -53,14 +51,6 @@ func createPr(target integration.Target, gbmPr repo.PullRequest, verbose bool) (
 	rpo, err := integration.PrepareBranch(target, gbmPr, verbose)
 	if err != nil {
 		return repo.PullRequest{}, err
-	}
-
-	org, _ := repo.GetOrg(target.Repo)
-	prompt := fmt.Sprintf("\nReady to create the PR on %s/%s?", org, target.Repo)
-	cont := utils.Confirm(prompt)
-	if !cont {
-		utils.LogInfo("Bye 👋")
-		os.Exit(0)
 	}
 
 	pr := repo.PullRequest{

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -15,10 +15,8 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 )
 
-func logger() func(string, ...interface{}) {
-	return func(f string, a ...interface{}) {
-		utils.LogInfo(f, a...)
-	}
+func l(f string, a ...interface{}) {
+	utils.LogInfo(f, a...)
 }
 
 type AztecSrc struct {

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -328,7 +328,7 @@ func CollectReleaseChanges(version string, changelog, relnotes []byte) ([]Releas
 
 				prId, _ := strconv.Atoi(matches[0][1])
 
-				pr, err := repo.GetPrOrg("WordPress", "gutenberg", prId)
+				pr, err := repo.GetPr("gutenberg", prId)
 				if err != nil {
 					utils.LogWarn("There was an issue fetching a gutenberg pr #%d", prId)
 					continue

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -87,6 +87,28 @@ func UpdateReleaseNotes(version, path string) error {
 	return readWriteNotes(version, path, releaseNotesUpdater)
 }
 
+// Check to see if the Gutenberg submodule in GBM is pointing to the
+// head of the Gutenberg release PR
+func IsGbmPrCurrent(version string) bool {
+	gbPr, err := repo.GetGbReleasePr(version)
+	if err != nil {
+		utils.LogWarn("Error getting Gutenberg Pr: %s", err)
+		return false
+	}
+	pr, err := repo.GetGbmReleasePr(version)
+	if err != nil {
+		utils.LogWarn("Error getting GB Mobile Pr: %s", err)
+		return false
+	}
+	submoduleStat, err := repo.GetContents("gutenberg-mobile", "gutenberg", pr.Head.Ref)
+	if err != nil {
+		utils.LogWarn("Error getting submodule status: %s", err)
+		return false
+	}
+
+	return gbPr.Head.Sha == submoduleStat.Sha
+}
+
 // See UpdateReleaseNotes
 // This handles the string replacement
 func releaseNotesUpdater(version string, notes []byte) []byte {


### PR DESCRIPTION
This adds an `update` sub command to `gbm release`.
For now it checks to see if the GBM PR is current with the GB release PR.
If it isn't it will update and run all the bundle steps.

This PR also includes a fair amount of refactoring to allow for updating existing release PRs

