### PR TITLE
Add a release publish command

### DIFF
--- a/cli/cmd/release/publish.go
+++ b/cli/cmd/release/publish.go
@@ -1,0 +1,47 @@
+package release
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/internal/utils"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
+)
+
+var PublishCmd = &cobra.Command{
+	Use:   "publish <version>",
+	Short: "generate the gutenberg release Prs",
+	Long: `
+`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		version := normalizeVersion(args[0])
+
+		prs := release.GetReleasePrs(version, "gutenberg-mobile", "gutenberg")
+		if len(prs) == 0 {
+			utils.LogError("No release PRs found")
+			os.Exit(1)
+		}
+		gbmPr := prs["gutenberg-mobile"]
+		gbPr := prs["gutenberg"]
+
+		l("Checking: ")
+		l("  - Gutenberg Mobile: %s", gbmPr.Url)
+		l("  - Gutenberg: %s\n", gbPr.Url)
+
+		if ready, reasons := release.IsReadyToPublish(version, skips, !Quite); !ready {
+			lWarn("🚨 The release is not ready to be published\n\n Reasons:")
+			for _, reason := range reasons {
+				lWarn("  - %s", reason)
+			}
+			os.Exit(1)
+		} else {
+			utils.LogInfo("🎉 The release is ready to be published")
+		}
+
+		os.Exit(0)
+	},
+}
+
+func init() {
+}

--- a/cli/cmd/release/publish.go
+++ b/cli/cmd/release/publish.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/internal/repo"
 	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 )
@@ -39,11 +40,39 @@ var PublishCmd = &cobra.Command{
 			utils.LogInfo("🎉 The release is ready to be published")
 		}
 
-		os.Exit(0)
+		l("\nTagging Gutenberg")
+		err := release.TagGb(version, !Quite)
+		if err != nil {
+			l(utils.WarnString("Tagging Gutenberg failed: %s", err))
+		}
+
+		l("\nPublishing the release")
+		err = release.PublishGbmRelease(version, !Quite)
+		if err != nil {
+			l(utils.ErrorString("Error publishing the release: %s", err))
+			os.Exit(1)
+		}
+
+		if Integrate {
+			Ios = true
+			Android = true
+		}
+
+		if Ios || Android {
+			l("\nUpdating the integration PRs with the release tag")
+			updateIntegration(version)
+		}
+
+		org, _ := repo.GetOrg("gutenberg-mobile")
+		l("\n🏁 The release has been published, check it out: https://github.com/%s/gutenberg-mobile/releases/tag/v%s", org, version)
+
 	},
 }
 
 func init() {
 	PublishCmd.Flags().BoolVarP(&Quite, "quite", "q", false, "silence output")
 	PublishCmd.Flags().BoolVarP(&SkipChecks, "skip-checks", "", false, "Skip the Check runs on the PR")
+	PublishCmd.Flags().BoolVarP(&All, "integrate", "i", false, "update integration PRs with release tag")
+	PublishCmd.Flags().BoolVarP(&Android, "android", "", false, "update android pr with release tag")
+	PublishCmd.Flags().BoolVarP(&Ios, "ios", "", false, "update ios pr with release tag")
 }

--- a/cli/cmd/release/publish.go
+++ b/cli/cmd/release/publish.go
@@ -29,7 +29,7 @@ var PublishCmd = &cobra.Command{
 		l("  - Gutenberg Mobile: %s", gbmPr.Url)
 		l("  - Gutenberg: %s\n", gbPr.Url)
 
-		if ready, reasons := release.IsReadyToPublish(version, skips, !Quite); !ready {
+		if ready, reasons := release.IsReadyToPublish(version, SkipChecks, !Quite); !ready {
 			lWarn("🚨 The release is not ready to be published\n\n Reasons:")
 			for _, reason := range reasons {
 				lWarn("  - %s", reason)
@@ -44,4 +44,6 @@ var PublishCmd = &cobra.Command{
 }
 
 func init() {
+	PublishCmd.Flags().BoolVarP(&Quite, "quite", "q", false, "silence output")
+	PublishCmd.Flags().BoolVarP(&SkipChecks, "skip-checks", "", false, "Skip the Check runs on the PR")
 }

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -27,6 +27,9 @@ var (
 	// Used by `prepare`
 	Gbm bool
 	All bool
+
+	// Used by `publish`
+	SkipChecks bool
 )
 
 type releaseResult struct {

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -30,6 +30,7 @@ var (
 
 	// Used by `publish`
 	SkipChecks bool
+	Integrate  bool
 )
 
 type releaseResult struct {

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -101,4 +101,5 @@ func init() {
 	RootCmd.AddCommand(IntegrateCmd)
 	RootCmd.AddCommand(StatusCmd)
 	RootCmd.AddCommand(UpdateCmd)
+	RootCmd.AddCommand(PublishCmd)
 }

--- a/cli/internal/repo/gh.go
+++ b/cli/internal/repo/gh.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
-	"github.com/fatih/color"
 	"github.com/wordpress-mobile/gbm-cli/internal/utils"
 )
 
@@ -27,21 +26,24 @@ type Repo struct {
 
 // PullRequest represents a GitHub pull request.
 // Not all fields are populated by all API calls.
+
+type User struct {
+	Login string
+}
 type PullRequest struct {
-	Number int
-	Url    string `json:"html_url"`
-	Body   string
-	Title  string
-	Labels []Label `json:"labels"`
-	State  string
-	User   struct {
-		Login string
-	}
-	Draft     bool
-	Mergeable bool
-	// Org       string
-	Head Repo
-	Base Repo
+	Number             int
+	Url                string `json:"html_url"`
+	ApiUrl             string `json:"url"`
+	Body               string
+	Title              string
+	Labels             []Label `json:"labels"`
+	State              string
+	User               User
+	Draft              bool
+	Mergeable          bool
+	Head               Repo
+	Base               Repo
+	RequestedReviewers []User `json:"requested_reviewers"`
 
 	// This field is not part of the GH api but is useful
 	// to get the context of the PR when passing it around
@@ -123,6 +125,22 @@ type GhContents struct {
 	Url  string
 }
 
+type Release struct {
+	Url           string `json:"url"`
+	TagName       string `json:"tag_name"`
+	PublishedDate string `json:"published_at"`
+	Draft         bool   `json:"draft"`
+	Prerelease    bool   `json:"prerelease"`
+	Target        string `json:"target_commitish"`
+}
+
+type ReleaseProps struct {
+	TagName         string `json:"tag_name"`
+	TargetCommitish string `json:"target_commitish"`
+	Name            string `json:"name"`
+	Body            string `json:"body"`
+}
+
 // GetPr returns a PullRequest struct for the given repo and PR number.
 func GetPr(repo string, id int) (*PullRequest, error) {
 	org, err := GetOrg(repo)
@@ -148,33 +166,6 @@ func GetPrOrg(org, repo string, id int) (*PullRequest, error) {
 	pr.Repo = repo
 
 	return pr, nil
-}
-
-func PreviewPr(repo, dir string, pr *PullRequest) {
-	org, _ := GetOrg(repo)
-	boldUnder := color.New(color.Bold, color.Underline).SprintFunc()
-	bold := color.New(color.Bold).SprintFunc()
-	cyan := color.New(color.FgCyan).SprintFunc()
-	fmt.Println(boldUnder("\nPr Preview"))
-	fmt.Println(bold("Local:"), "\t", cyan(dir))
-	fmt.Println(bold("Repo:"), "\t", cyan(fmt.Sprintf("%s/%s", org, repo)))
-	fmt.Println(bold("Title:"), "\t", cyan(pr.Title))
-	fmt.Print(bold("Body:\n"), cyan(pr.Body))
-	fmt.Println(bold("Commits:"))
-	exc := exec.Command(
-		"git",
-		"log",
-		"trunk...HEAD",
-		"--oneline",
-		"--no-merges",
-		"-10",
-	)
-	exc.Dir = dir
-	exc.Stdout = os.Stdout
-
-	if err := exc.Run(); err != nil {
-		fmt.Println(err)
-	}
 }
 
 func CreatePr(repo string, pr *PullRequest) error {
@@ -296,7 +287,7 @@ func BuildRepoFilter(repo string, queries ...string) RepoFilter {
 	// We just need to warn if the org is not found.
 	org, err := GetOrg(repo)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+		l(utils.WarnString("could not find org for %s", err))
 	}
 	var encoded []string
 	queries = append(queries, fmt.Sprintf("repo:%s/%s", org, repo))
@@ -351,7 +342,7 @@ func FindGbmSyncedPrs(gbmPr PullRequest, filters []RepoFilter) ([]SearchResult, 
 
 			// just log the error and continue
 			if err != nil {
-				fmt.Println(err)
+				l(utils.WarnString("could not search for %s", err))
 			}
 			prChan <- res
 		}(rf)
@@ -378,17 +369,14 @@ func FindGbmSyncedPrs(gbmPr PullRequest, filters []RepoFilter) ([]SearchResult, 
 func GetPrStatus(pr *PullRequest) (RefStatus, error) {
 	org, repo, err := getOrgRepo(pr)
 	if err != nil {
-		utils.LogError("%s", err)
 		return RefStatus{}, err
 	}
 	client := getClient()
 	ref := pr.Head.Ref
 
 	endpoint := fmt.Sprintf("repos/%s/%s/commits/%s/status", org, repo, ref)
-	utils.LogDebug(endpoint)
 	fs := RefStatus{}
 	if err := client.Get(endpoint, &fs); err != nil {
-		fmt.Println(err)
 		return RefStatus{}, err
 	}
 
@@ -407,6 +395,146 @@ func GetContents(repo, file, branch string) (GhContents, error) {
 		return GhContents{}, err
 	}
 	return response, nil
+}
+
+func GetRelease(repo, version string) (Release, error) {
+	org, err := GetOrg(repo)
+	if err != nil {
+		return Release{}, err
+	}
+	client := getClient()
+	endpoint := fmt.Sprintf("repos/%s/%s/releases/tags/%s", org, repo, version)
+	response := Release{}
+	if err := client.Get(endpoint, &response); err != nil {
+		return Release{}, err
+	}
+	return response, nil
+}
+
+func CreateRelease(repo string, rp *ReleaseProps) error {
+	client := getClient()
+	org, err := GetOrg(repo)
+	if err != nil {
+		return err
+	}
+	endpoint := fmt.Sprintf("repos/%s/%s/releases", org, repo)
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(rp); err != nil {
+		return err
+	}
+
+	resp := http.Response{}
+
+	if err := client.Post(endpoint, &buf, resp); err != nil {
+		return err
+	}
+	if resp.StatusCode != 201 {
+		return fmt.Errorf("Error creating release: %s", resp.Status)
+	}
+	return nil
+}
+
+type Review struct {
+	State string `json:"state"`
+}
+
+// The PR is considered approved if the last review is approved and there are no pending reviews.
+// We don't care which commit was approved, just that the PR is approved.
+func IsPrApproved(pr *PullRequest) bool {
+	client := getClient()
+	org, repo, err := getOrgRepo(pr)
+	if err != nil {
+		return false
+	}
+	endpoint := fmt.Sprintf("repos/%s/%s/pulls/%d/reviews", org, repo, pr.Number)
+
+	reviews := []Review{}
+
+	if err := client.Get(endpoint, &reviews); err != nil {
+		l(utils.WarnString("Error getting reviews: %v", err))
+		return false
+	}
+
+	numR := len(reviews)
+
+	if numR == 0 {
+		return false
+	}
+
+	// If the last review is not approved, not approved
+	if reviews[numR-1].State != "APPROVED" {
+		return false
+	}
+
+	// Check to see if there is an additional review request
+	if pr.RequestedReviewers != nil && len(pr.RequestedReviewers) > 0 {
+		return false
+	}
+
+	return true
+}
+
+type CheckRun struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+type CheckRuns struct {
+	TotalCount int        `json:"total_count"`
+	CheckRuns  []CheckRun `json:"check_runs"`
+}
+
+// Checks to see if the run checks are passing.
+// Use verbose to output which checks are failing.
+// Also accepts a list of checks to skip.
+func IsPrPassing(pr *PullRequest, skipRuns []CheckRun, verbose bool) bool {
+	org, repo, err := getOrgRepo(pr)
+	if err != nil {
+		return false
+	}
+	client := getClient()
+	endpoint := fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", org, repo, pr.Head.Sha)
+	checkRuns := CheckRuns{}
+	if err := client.Get(endpoint, &checkRuns); err != nil {
+		l(utils.WarnString("Error getting check runs: %v", err))
+		return false
+	}
+
+	ok := func(c string) bool {
+		if c == "neutral" || c == "skipped" || c == "success" {
+			return true
+		}
+		return false
+	}
+
+	skipped := func(n string) bool {
+		for _, sr := range skipRuns {
+			if sr.Name == n {
+				return true
+			}
+		}
+		return false
+	}
+
+	if verbose {
+		l(utils.InfoString("Checking runs checks for %s/%s@%s", org, repo, pr.Head.Sha))
+	}
+	passed := true
+	for _, checkRun := range checkRuns.CheckRuns {
+		if checkRun.Status == "completed" && !ok(checkRun.Conclusion) {
+			if !skipped(checkRun.Name) {
+				passed = false
+				if verbose {
+					l(utils.WarnString("Check run '%s' failed with conclusion %s", checkRun.Name, checkRun.Conclusion))
+				}
+			}
+		}
+	}
+	if verbose {
+		l("")
+	}
+
+	return passed
 }
 
 // getClient returns a REST client for the GitHub API.

--- a/cli/internal/repo/git.go
+++ b/cli/internal/repo/git.go
@@ -34,7 +34,6 @@ func getAuth() *http.BasicAuth {
 }
 
 func getSignature() *object.Signature {
-	// Load the config from 'gh'
 	config, _ := config.LoadConfig(config.GlobalScope)
 	u := config.User
 	s := object.Signature{

--- a/cli/pkg/release/publish.go
+++ b/cli/pkg/release/publish.go
@@ -1,13 +1,19 @@
 package release
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/wordpress-mobile/gbm-cli/internal/repo"
+	"github.com/wordpress-mobile/gbm-cli/internal/utils"
+	"github.com/wordpress-mobile/gbm-cli/pkg/render"
 )
 
 // Checks if the release PRs: exist, mergable, approved, and are passing.
 // It returns early for non-existent PRs, otherwise it collects the reasons for
 // not being ready to publish.
-func IsReadyToPublish(version string, skipChecks []repo.CheckRun, verbose bool) (bool, []string) {
+func IsReadyToPublish(version string, skipChecks, verbose bool) (bool, []string) {
 	prs := GetReleasePrs(version, "gutenberg-mobile", "gutenberg")
 	if len(prs) == 0 {
 		return false, []string{"No release PRs found"}
@@ -44,15 +50,67 @@ func IsReadyToPublish(version string, skipChecks []repo.CheckRun, verbose bool) 
 		reasons = append(reasons, "GBM PR is not approved")
 	}
 
-	if !repo.IsPrPassing(gbPr, skipChecks, verbose) {
-		ok = false
-		reasons = append(reasons, "GB PR is not passing")
-	}
+	if skipChecks {
+		l(utils.WarnString("Skipping check runs"))
+	} else {
+		if !repo.IsPrPassing(gbPr, nil, verbose) {
+			ok = false
+			reasons = append(reasons, "GB PR is not passing")
+		}
 
-	if !repo.IsPrPassing(gbmPr, skipChecks, verbose) {
-		ok = false
-		reasons = append(reasons, "GBM PR is not passing")
+		if !repo.IsPrPassing(gbmPr, nil, verbose) {
+			ok = false
+			reasons = append(reasons, "GBM PR is not passing")
+		}
 	}
 
 	return ok, reasons
+}
+
+func TagGb(version string, verbose bool) error {
+	return nil
+}
+
+func PublishGbmRelease(version string, verbose bool) error {
+
+	// Get the new release notes for the GBM release
+	org, _ := repo.GetOrg("gutenberg-mobile")
+	rnUrl := fmt.Sprintf("https://raw.githubusercontent.com/%s/gutenberg-mobile/release/%s/RELEASE-NOTES.txt", org, version)
+	resp, err := http.Get(rnUrl)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	relNotes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// Collect the changes from the GBM release notes
+	changes, err := CollectReleaseChanges(version, nil, relNotes)
+	if err != nil {
+		return err
+	}
+
+	// Render the release body
+	data := struct {
+		Changes []ReleaseChanges
+	}{
+		Changes: changes,
+	}
+
+	body, err := render.Render("templates/release/gbmReleaseBody.md", data, nil)
+	if err != nil {
+		return err
+	}
+
+	// Create the release
+	rp := &repo.ReleaseProps{
+		TagName:         "v" + version,
+		TargetCommitish: "release/" + version,
+		Name:            "Release " + version,
+		Body:            body,
+	}
+
+	return repo.CreateRelease("gutenberg-mobile", rp)
 }

--- a/cli/pkg/release/publish.go
+++ b/cli/pkg/release/publish.go
@@ -1,0 +1,58 @@
+package release
+
+import (
+	"github.com/wordpress-mobile/gbm-cli/internal/repo"
+)
+
+// Checks if the release PRs: exist, mergable, approved, and are passing.
+// It returns early for non-existent PRs, otherwise it collects the reasons for
+// not being ready to publish.
+func IsReadyToPublish(version string, skipChecks []repo.CheckRun, verbose bool) (bool, []string) {
+	prs := GetReleasePrs(version, "gutenberg-mobile", "gutenberg")
+	if len(prs) == 0 {
+		return false, []string{"No release PRs found"}
+	}
+	ok := true
+	reasons := []string{}
+	gbmPr := prs["gutenberg-mobile"]
+	gbPr := prs["gutenberg"]
+
+	if gbmPr == nil {
+		return false, []string{"GBM PR does not exist"}
+	}
+	if gbPr == nil {
+		return false, []string{"GB PR does not exist"}
+	}
+
+	// From now on, collect the reasons for not being ready to publish
+	if !gbmPr.Mergeable {
+		ok = false
+		reasons = append(reasons, "GBM PR is not mergeable")
+	}
+	if !gbPr.Mergeable {
+		ok = false
+		reasons = append(reasons, "GB PR is not mergeable")
+	}
+
+	if !repo.IsPrApproved(gbPr) {
+		ok = false
+		reasons = append(reasons, "GB PR is not approved")
+	}
+
+	if !repo.IsPrApproved(gbmPr) {
+		ok = false
+		reasons = append(reasons, "GBM PR is not approved")
+	}
+
+	if !repo.IsPrPassing(gbPr, skipChecks, verbose) {
+		ok = false
+		reasons = append(reasons, "GB PR is not passing")
+	}
+
+	if !repo.IsPrPassing(gbmPr, skipChecks, verbose) {
+		ok = false
+		reasons = append(reasons, "GBM PR is not passing")
+	}
+
+	return ok, reasons
+}


### PR DESCRIPTION
This adds the command `gbm release publish <version>`
It will:

- Verify that the release can be published 
   - The GB and GBM prs are reviewed, mergable and Check runs passed ( this part can be bypassed with `--skip-checks` )
- Creates the release on GBM
- Tags GB with the release tag
- Optionally updates the release integrations with the GBM release tag via the integration flags 
