### PR TITLE
Update docs to clarify betafix and hotfix branch cut sources

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -387,7 +387,7 @@ At the same time there could also be a regular release going on for example for 
 | Repo             | Cut From                | Branch Name                        | Merging To                                                       |
 | ---------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------- |
 | gutenberg        | rnmobile/release_1.11.0 (tag) | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.0                     |
-| gutenberg-mobile | v1.11.1 (tag)          | release/1.11.1                     | trunk & (maybe also) release/1.12.0                              |
+| gutenberg-mobile | v1.11.0 (tag)          | release/1.11.1                     | trunk & (maybe also) release/1.12.0                              |
 | WPAndroid        | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.0 & (maybe also) gutenberg/integrate_release_1.12.0 |
 | WPiOS            | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.0 & (maybe also) gutenberg/integrate_release_1.12.0 |
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -417,7 +417,7 @@ At the same time there could also be a regular release, a betafix or even anothe
 | Repo             | Cut From                | Branch Name                        | Merging To                                                       |
 | ---------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------- |
 | gutenberg        | rnmobile/release_1.11.0 (tag) | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.1                     |
-| gutenberg-mobile | v1.11.1 (tag)          | release/1.11.1                     | trunk & (maybe also) release/1.12.1                              |
+| gutenberg-mobile | v1.11.0 (tag)          | release/1.11.1                     | trunk & (maybe also) release/1.12.1                              |
 | WPAndroid        | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.1 & (maybe also) gutenberg/integrate_release_1.12.1 |
 | WPiOS            | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.1 & (maybe also) gutenberg/integrate_release_1.12.1 |
 

--- a/Releasing.md
+++ b/Releasing.md
@@ -386,8 +386,8 @@ At the same time there could also be a regular release going on for example for 
 
 | Repo             | Cut From                | Branch Name                        | Merging To                                                       |
 | ---------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------- |
-| gutenberg        | rnmobile/release_1.11.0 | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.0                     |
-| gutenberg-mobile | release/1.11.0          | release/1.11.1                     | trunk & (maybe also) release/1.12.0                              |
+| gutenberg        | rnmobile/release_1.11.0 (tag) | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.0                     |
+| gutenberg-mobile | v1.11.1 (tag)          | release/1.11.1                     | trunk & (maybe also) release/1.12.0                              |
 | WPAndroid        | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.0 & (maybe also) gutenberg/integrate_release_1.12.0 |
 | WPiOS            | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.0 & (maybe also) gutenberg/integrate_release_1.12.0 |
 
@@ -416,8 +416,8 @@ At the same time there could also be a regular release, a betafix or even anothe
 
 | Repo             | Cut From                | Branch Name                        | Merging To                                                       |
 | ---------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------- |
-| gutenberg        | rnmobile/release_1.11.0 | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.1                     |
-| gutenberg-mobile | release/1.11.0          | release/1.11.1                     | trunk & (maybe also) release/1.12.1                              |
+| gutenberg        | rnmobile/release_1.11.0 (tag) | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.1                     |
+| gutenberg-mobile | v1.11.1 (tag)          | release/1.11.1                     | trunk & (maybe also) release/1.12.1                              |
 | WPAndroid        | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.1 & (maybe also) gutenberg/integrate_release_1.12.1 |
 | WPiOS            | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.1 & (maybe also) gutenberg/integrate_release_1.12.1 |
 


### PR DESCRIPTION
Updates doc references to clarify which tags/branches hotfixes and betafixes should be cut from. 