### PR TITLE
Update NextReleaseDate util to display the correct date

### DIFF
--- a/cli/pkg/utils/utils.go
+++ b/cli/pkg/utils/utils.go
@@ -25,7 +25,7 @@ func NextReleaseDate() string {
 
 	nextThursday := time.Now().AddDate(0, 0, int(daysUntilThursday))
 
-	return nextThursday.Format("Monday 01, 2006")
+	return nextThursday.Format("Monday January 2, 2006")
 }
 
 func NormalizeVersion(version string) (string, error) {

--- a/cli/pkg/utils/utils_test.go
+++ b/cli/pkg/utils/utils_test.go
@@ -3,13 +3,27 @@ package utils
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNextReleaseDate(t *testing.T) {
 
-	t.Run("It returns the next Thursday", func(t *testing.T) {
+	t.Run("It returns the next Thursday in the correct month", func(t *testing.T) {
 		got := NextReleaseDate()
 
+		// Parse the date string to get the month
+		date, err := time.Parse("Monday January 2, 2006", got)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		month := date.Month()
+
+		// Check that the month is correct
+		if month != time.January && month != time.February && month != time.March && month != time.April && month != time.May && month != time.June && month != time.July && month != time.August && month != time.September && month != time.October && month != time.November && month != time.December {
+			t.Fatalf("Expected %s to be in a valid month, got %s", got, month)
+		}
+
+		// Check that the day is a Thursday
 		if !strings.Contains(got, "Thursday") {
 			t.Fatalf("Expected %s to contain %s", got, "Thursday")
 		}


### PR DESCRIPTION
Updates the CLI `NextReleaseDate` util to display the correct next release date:

* https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/156

**To test:** 

Run `go run main.go render checklist -v 1.0.0` from the `cli` directory, and verify that the date output in the `Hey [author]` quote is the correct date for next Thursday:

```
Hey [author]. We will cut the 1.0.0 release on Thursday October 12, 2023. I plan to circle back and bump this PR...
```





I believe the original issue was because the first Monday in January 2006 was January the 2nd, not January the 1st:

```
- return nextThursday.Format("Monday 01, 2006")
+ return nextThursday.Format("Monday January 2, 2006")
```

I also added the month, which I though should be included. Previously, the command would render "We will cut the release on Thursday 10, 2023", which felt a bit odd without the name of month included. Also updated the test to reflect this.