### PR TITLE
[CLI] UIpdate git package to use a client

### DIFF
--- a/cli/pkg/exec/exec.go
+++ b/cli/pkg/exec/exec.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 )
 
-func ExecGit(dir string, verbose bool) func(...string) error {
+func Git(dir string, verbose bool) func(...string) error {
 	return func(cmds ...string) error {
 		cmd := exec.Command("git", cmds...)
 		cmd.Dir = dir
@@ -17,6 +17,11 @@ func ExecGit(dir string, verbose bool) func(...string) error {
 
 		return cmd.Run()
 	}
+}
+
+// Deprecated: Use Git instead
+func ExecGit(dir string, verbose bool) func(...string) error {
+	return Git(dir, verbose)
 }
 
 func SetupNode(dir string, verbose bool) error {

--- a/cli/pkg/git/git.go
+++ b/cli/pkg/git/git.go
@@ -6,26 +6,44 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/pkg/exec"
 )
 
-func Clone(repo, dir string, shallow bool) error {
-	cmd := exec.ExecGit(dir, true)
-	if shallow {
-		return cmd("clone", "--depth", "1", repo)
+type Client interface {
+	Clone(...string) error
+	Switch(...string) error
+	CommitAll(string, ...interface{}) error
+	Push() error
+}
+
+type client struct {
+	dir     string
+	verbose bool
+}
+
+func NewClient(dir string, verbose bool) Client {
+	return &client{
+		dir:     dir,
+		verbose: verbose,
 	}
-	return cmd("clone", repo)
 }
 
-func Switch(dir, branch string, create bool) error {
-	cmd := exec.ExecGit(dir, true)
-	if create {
-		return cmd("switch", "-c", branch)
-	}
-	return cmd("switch", branch)
+func (c *client) Clone(args ...string) error {
+	cmd := exec.Git(c.dir, c.verbose)
+	clone := append([]string{"clone"}, args...)
+	return cmd(clone...)
 }
 
-func CommitAll(dir, format string, args ...interface{}) error {
-	return exec.ExecGit(dir, true)("commit", "-am", fmt.Sprintf(format, args...))
+func (c *client) Switch(args ...string) error {
+	cmd := exec.Git(c.dir, c.verbose)
+	swtch := append([]string{"switch"}, args...)
+	return cmd(swtch...)
 }
 
-func Push(dir, branch string) error {
-	return exec.ExecGit(dir, true)("push", "origin", branch)
+func (c *client) CommitAll(format string, args ...interface{}) error {
+	cmd := exec.Git(c.dir, c.verbose)
+	message := fmt.Sprintf(format, args...)
+	return cmd("commit", "-am", message)
+}
+
+func (c *client) Push() error {
+	cmd := exec.Git(c.dir, c.verbose)
+	return cmd("push", "origin", "HEAD")
 }

--- a/cli/pkg/git/git.go
+++ b/cli/pkg/git/git.go
@@ -11,6 +11,7 @@ type Client interface {
 	Switch(...string) error
 	CommitAll(string, ...interface{}) error
 	Push() error
+	RemoteExists(string, string) bool
 }
 
 type client struct {
@@ -46,4 +47,10 @@ func (c *client) CommitAll(format string, args ...interface{}) error {
 func (c *client) Push() error {
 	cmd := exec.Git(c.dir, c.verbose)
 	return cmd("push", "origin", "HEAD")
+}
+
+func (c *client) RemoteExists(remote, branch string) bool {
+	cmd := exec.Git(c.dir, c.verbose)
+	err := cmd("ls-remote", "--exit-code", "--heads", remote, branch)
+	return err == nil
 }

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/exec"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
-	"github.com/wordpress-mobile/gbm-cli/pkg/git"
+	g "github.com/wordpress-mobile/gbm-cli/pkg/git"
 	"github.com/wordpress-mobile/gbm-cli/pkg/render"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
@@ -15,6 +15,8 @@ import (
 
 func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 	var pr gh.PullRequest
+
+	git := g.NewClient(dir, true)
 
 	org, err := repo.GetOrg("gutenberg")
 	console.ExitIfError(err)
@@ -31,13 +33,14 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 		return pr, nil
 	} else {
 		console.Info("Cloning Gutenberg to %s", dir)
-		err := git.Clone(repo.GetRepoPath("gutenberg"), dir, true)
+
+		err := git.Clone(repo.GetRepoPath("gutenberg"), "--depth=1")
 		if err != nil {
 			return pr, err
 		}
 
 		console.Info("Checking out branch %s", branch)
-		err = git.Switch(gbDir, branch, true)
+		err = git.Switch(branch, "-c")
 		if err != nil {
 			return pr, err
 		}
@@ -118,7 +121,7 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 		return pr, fmt.Errorf("exiting before creating PR")
 	}
 
-	if err := git.Push(gbDir, branch); err != nil {
+	if err := git.Push(); err != nil {
 		return pr, err
 	}
 


### PR DESCRIPTION
This replaces the existing git functions with a client interface.
This simplifies the cases where multiple git commands are used. 

Example
```
// git package imported as `g`
git := g.NewGitClient(directory, true)
git.Clone(repo, "depth=1")
git.Switch(branch, "--create")
...
git.Push()
```
