### PR TITLE
[CLI] Add new subcommand for target repos

### DIFF
--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -1,0 +1,38 @@
+package prepare
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
+	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
+)
+
+var gbCmd = &cobra.Command{
+	Use:   "gb",
+	Short: "Prepare Gutenberg for a mobile release",
+	Long:  `Use this command to prepare a Gutenberg release PR`,
+	Run: func(cmd *cobra.Command, args []string) {
+		version, err := getVersionArg(args)
+		console.ExitIfError(err)
+
+		// Validate Aztec version
+		if valid := gbm.ValidateAztecVersions(); !valid {
+			console.ExitError("Aztec versions are not valid")
+		}
+
+		console.Info("Preparing Gutenberg for release %s", version)
+
+		tempDir, err := utils.SetTempDir()
+		console.ExitIfError(err)
+
+		defer utils.CleanupTempDir(tempDir)
+
+		console.Info("Created temporary directory %s", tempDir)
+
+		pr, err := release.CreateGbPR(version, tempDir)
+		console.ExitIfError(err)
+
+		console.Info("Created PR %s", pr.Url)
+	},
+}

--- a/cli/cmd/release/prepare/gbm.go
+++ b/cli/cmd/release/prepare/gbm.go
@@ -1,17 +1,16 @@
-package release
+package prepare
 
 import (
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
-	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
 )
 
-var PrepareCmd = &cobra.Command{
-	Use:   "prepare",
-	Short: "Prepare a release",
-	Long:  `Use this command to prepare a release`,
+var gbmCmd = &cobra.Command{
+	Use:   "gbm",
+	Short: "Prepare Gutenberg Mobile release",
+	Long:  `Use this command to prepare a Gutenberg Mobile release PR`,
 	Run: func(cmd *cobra.Command, args []string) {
 		version, err := getVersionArg(args)
 		console.ExitIfError(err)
@@ -21,7 +20,7 @@ var PrepareCmd = &cobra.Command{
 			console.ExitError("Aztec versions are not valid")
 		}
 
-		console.Info("Preparing release for version %s", version)
+		console.Info("Preparing Gutenberg Mobile for release %s", version)
 
 		tempDir, err := utils.SetTempDir()
 		console.ExitIfError(err)
@@ -30,9 +29,6 @@ var PrepareCmd = &cobra.Command{
 
 		console.Info("Created temporary directory %s", tempDir)
 
-		pr, err := release.CreateGbPR(version, tempDir)
-		console.ExitIfError(err)
-
-		console.Info("Created PR  %s", pr.Url)
+		// console.ExitError("not implemented")
 	},
 }

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -1,0 +1,32 @@
+package prepare
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
+)
+
+var PrepareCmd = &cobra.Command{
+	Use:   "prepare",
+	Short: "Prepare for a release",
+}
+
+func Execute() {
+	err := PrepareCmd.Execute()
+	console.ExitIfError(err)
+}
+
+func init() {
+	PrepareCmd.AddCommand(gbmCmd)
+	PrepareCmd.AddCommand(gbCmd)
+}
+
+func getVersionArg(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("missing version")
+	}
+
+	return utils.NormalizeVersion(args[0])
+}

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -1,11 +1,9 @@
 package release
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/cmd/release/prepare"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
 )
 
 var ReleaseCmd = &cobra.Command{
@@ -19,13 +17,5 @@ func Execute() {
 }
 
 func init() {
-	ReleaseCmd.AddCommand(PrepareCmd)
-}
-
-func getVersionArg(args []string) (string, error) {
-	if len(args) == 0 {
-		return "", fmt.Errorf("missing version")
-	}
-
-	return utils.NormalizeVersion(args[0])
+	ReleaseCmd.AddCommand(prepare.PrepareCmd)
 }

--- a/cli/pkg/utils/utils.go
+++ b/cli/pkg/utils/utils.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"regexp"
 	"time"
+
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 )
 
 func ValidateVersion(version string) bool {
@@ -50,6 +52,7 @@ func SetTempDir() (string, error) {
 }
 
 func CleanupTempDir(tempDir string) error {
+	console.Info("Cleaning up temporary directory %s", tempDir)
 	err := os.RemoveAll(tempDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds two new sub commands to `prepare`
- `release prepare gb`
- `release prepare gbm`

The former is the same as the existing `release prepare`
The later is just a stub for now.