### PR TITLE
[CLI] improve exit handling

### DIFF
--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -1,37 +1,40 @@
 package prepare
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release"
-	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
 )
 
 var gbCmd = &cobra.Command{
 	Use:   "gb",
 	Short: "Prepare Gutenberg for a mobile release",
 	Long:  `Use this command to prepare a Gutenberg release PR`,
-	Run: func(cmd *cobra.Command, args []string) {
-		version, err := getVersionArg(args)
-		console.ExitIfError(err)
+	Run: func(cc *cobra.Command, args []string) {
+
+		version, err := utils.GetVersionArg(args)
+		exitIfError(err, 1)
 
 		// Validate Aztec version
 		if valid := gbm.ValidateAztecVersions(); !valid {
-			console.ExitError("Aztec versions are not valid")
+			exitIfError(errors.New("invalid Aztec versions found"), 1)
 		}
 
 		console.Info("Preparing Gutenberg for release %s", version)
 
-		tempDir, err := utils.SetTempDir()
-		console.ExitIfError(err)
+		tempDir, err = utils.SetTempDir()
+		exitIfError(err, 1)
 
-		defer utils.CleanupTempDir(tempDir)
+		defer cleanup()
 
 		console.Info("Created temporary directory %s", tempDir)
 
 		pr, err := release.CreateGbPR(version, tempDir)
-		console.ExitIfError(err)
+		exitIfError(err, 1)
 
 		console.Info("Created PR %s", pr.Url)
 	},

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -26,10 +26,15 @@ var gbCmd = &cobra.Command{
 
 		console.Info("Preparing Gutenberg for release %s", version)
 
-		tempDir, err = utils.SetTempDir()
+		tempDir, err := utils.SetTempDir()
 		exitIfError(err, 1)
-
+		cleanup := func() {
+			utils.CleanupTempDir(tempDir)
+		}
 		defer cleanup()
+
+		// Reset the exitIfError to handle the cleanup
+		exitIfError = utils.ExitIfErrorHandler(cleanup)
 
 		console.Info("Created temporary directory %s", tempDir)
 

--- a/cli/cmd/release/prepare/gbm.go
+++ b/cli/cmd/release/prepare/gbm.go
@@ -1,10 +1,12 @@
 package prepare
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
-	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
 )
 
 var gbmCmd = &cobra.Command{
@@ -12,23 +14,23 @@ var gbmCmd = &cobra.Command{
 	Short: "Prepare Gutenberg Mobile release",
 	Long:  `Use this command to prepare a Gutenberg Mobile release PR`,
 	Run: func(cmd *cobra.Command, args []string) {
-		version, err := getVersionArg(args)
-		console.ExitIfError(err)
+		version, err := utils.GetVersionArg(args)
+		exitIfError(err, 1)
 
 		// Validate Aztec version
 		if valid := gbm.ValidateAztecVersions(); !valid {
-			console.ExitError("Aztec versions are not valid")
+			exitIfError(errors.New("the Aztec versions are not valid"), 1)
 		}
 
 		console.Info("Preparing Gutenberg Mobile for release %s", version)
 
 		tempDir, err := utils.SetTempDir()
-		console.ExitIfError(err)
+		exitIfError(err, 1)
 
 		defer utils.CleanupTempDir(tempDir)
 
 		console.Info("Created temporary directory %s", tempDir)
 
-		// console.ExitError("not implemented")
+		exitIfError(errors.New("not implemented"), 1)
 	},
 }

--- a/cli/cmd/release/prepare/gbm.go
+++ b/cli/cmd/release/prepare/gbm.go
@@ -27,7 +27,13 @@ var gbmCmd = &cobra.Command{
 		tempDir, err := utils.SetTempDir()
 		exitIfError(err, 1)
 
-		defer utils.CleanupTempDir(tempDir)
+		cleanup := func() {
+			utils.CleanupTempDir(tempDir)
+		}
+
+		// Reset the exitIfError to handle the cleanup
+		exitIfError = utils.ExitIfErrorHandler(cleanup)
+		defer cleanup()
 
 		console.Info("Created temporary directory %s", tempDir)
 

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -5,8 +5,6 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 )
 
-var tempDir string
-var cleanup func()
 var exitIfError func(error, int)
 
 var PrepareCmd = &cobra.Command{
@@ -20,12 +18,7 @@ func Execute() {
 }
 
 func init() {
-	cleanup = func() {
-		if tempDir != "" {
-			utils.CleanupTempDir(tempDir)
-		}
-	}
-	exitIfError = utils.ExitIfErrorHandler(cleanup)
+	exitIfError = utils.ExitIfErrorHandler(func() {})
 
 	PrepareCmd.AddCommand(gbmCmd)
 	PrepareCmd.AddCommand(gbCmd)

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -1,12 +1,13 @@
 package prepare
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
+	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 )
+
+var tempDir string
+var cleanup func()
+var exitIfError func(error, int)
 
 var PrepareCmd = &cobra.Command{
 	Use:   "prepare",
@@ -15,18 +16,17 @@ var PrepareCmd = &cobra.Command{
 
 func Execute() {
 	err := PrepareCmd.Execute()
-	console.ExitIfError(err)
+	exitIfError(err, 1)
 }
 
 func init() {
+	cleanup = func() {
+		if tempDir != "" {
+			utils.CleanupTempDir(tempDir)
+		}
+	}
+	exitIfError = utils.ExitIfErrorHandler(cleanup)
+
 	PrepareCmd.AddCommand(gbmCmd)
 	PrepareCmd.AddCommand(gbCmd)
-}
-
-func getVersionArg(args []string) (string, error) {
-	if len(args) == 0 {
-		return "", fmt.Errorf("missing version")
-	}
-
-	return utils.NormalizeVersion(args[0])
 }

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -1,6 +1,8 @@
 package release
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/cmd/release/prepare"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
@@ -13,7 +15,10 @@ var ReleaseCmd = &cobra.Command{
 
 func Execute() {
 	err := ReleaseCmd.Execute()
-	console.ExitIfError(err)
+	if err != nil {
+		console.Error(err)
+		os.Exit(1)
+	}
 }
 
 func init() {

--- a/cli/cmd/render/aztec.go
+++ b/cli/cmd/render/aztec.go
@@ -10,8 +10,7 @@ var AztecCmd = &cobra.Command{
 	Short: "Render the steps for upgrading Aztec",
 	Run: func(cmd *cobra.Command, args []string) {
 		result, err := renderAztecSteps(false)
-
-		console.ExitIfError(err)
+		exitIfError(err, 1)
 
 		if writeToClipboard {
 			console.Clipboard(result)

--- a/cli/cmd/render/checklist.go
+++ b/cli/cmd/render/checklist.go
@@ -39,7 +39,7 @@ var ChecklistCmd = &cobra.Command{
 
 		vv := utils.ValidateVersion(version)
 		if !vv {
-			console.ExitError("%v is not a valid version. Versions must have a `Major.Minor.Patch` form", version)
+			exitIfError(fmt.Errorf("%v is not a valid version. Versions must have a `Major.Minor.Patch` form", version), 1)
 		}
 
 		// For now let's assume we should include the Aztec steps unless explicitly checking if the versions are valid.
@@ -76,7 +76,7 @@ var ChecklistCmd = &cobra.Command{
 		}
 
 		result, err := render.RenderTasks(t)
-		console.ExitIfError(err)
+		exitIfError(err, 1)
 
 		if writeToClipboard {
 			console.Clipboard(result)

--- a/cli/cmd/render/root.go
+++ b/cli/cmd/render/root.go
@@ -4,9 +4,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 )
 
 var writeToClipboard bool
+var exitIfError func(error, int)
 
 // rootCmd represents the render command
 var RenderCmd = &cobra.Command{
@@ -25,6 +27,7 @@ var RenderCmd = &cobra.Command{
 }
 
 func init() {
+	exitIfError = utils.ExitIfErrorHandler(func() {})
 	RenderCmd.AddCommand(ChecklistCmd)
 	RenderCmd.AddCommand(AztecCmd)
 	RenderCmd.PersistentFlags().BoolVar(&writeToClipboard, "c", false, "Send output to clipboard")

--- a/cli/cmd/utils/utils.go
+++ b/cli/cmd/utils/utils.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
+)
+
+func GetVersionArg(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("missing version")
+	}
+	return utils.NormalizeVersion(args[0])
+}
+
+func SetTempDir() (string, error) {
+	tempDir, err := os.MkdirTemp("", "gbm-")
+	if err != nil {
+		return "", err
+	}
+	return tempDir, nil
+}
+
+func CleanupTempDir(tempDir string) error {
+	console.Info("Cleaning up temporary directory %s", tempDir)
+	err := os.RemoveAll(tempDir)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ExitIfErrorHandler(deferred func()) func(error, int) {
+	return func(err error, code int) {
+		if err != nil {
+			console.Error(err)
+
+			os.Exit(func() int {
+				defer deferred()
+				return code
+			}())
+
+		}
+	}
+}

--- a/cli/cmd/utils/utils.go
+++ b/cli/cmd/utils/utils.go
@@ -37,11 +37,14 @@ func ExitIfErrorHandler(deferred func()) func(error, int) {
 		if err != nil {
 			console.Error(err)
 
-			os.Exit(func() int {
-				defer deferred()
-				return code
-			}())
-
+			Exit(deferred, code)
 		}
 	}
+}
+
+func Exit(deferred func(), code int) {
+	os.Exit(func() int {
+		defer deferred()
+		return code
+	}())
 }

--- a/cli/pkg/console/console.go
+++ b/cli/pkg/console/console.go
@@ -78,6 +78,12 @@ func Warn(format string, args ...interface{}) {
 	color.Unset()
 }
 
+func Error(err error) {
+	red := color.New(color.FgRed).SprintfFunc()
+	l.Printf(red("\n" + err.Error()))
+	color.Unset()
+}
+
 func Confirm(ask string) bool {
 	reader := bufio.NewReader(os.Stdin)
 

--- a/cli/pkg/console/console.go
+++ b/cli/pkg/console/console.go
@@ -19,12 +19,14 @@ func init() {
 	l = log.New(os.Stderr, "", 0)
 }
 
+// Deprecated
 func ExitIfError(err error) {
 	if err != nil {
 		ExitError(err.Error() + "\n")
 	}
 }
 
+// Deprecated
 func ExitError(format string, args ...interface{}) {
 	if len(args) == 0 {
 		Exit(1, format)
@@ -33,6 +35,7 @@ func ExitError(format string, args ...interface{}) {
 	}
 }
 
+// Deprecated
 func Exit(code int, format string, args ...interface{}) {
 	red := color.New(color.FgRed).SprintfFunc()
 	l.Printf(red("\n"+format, args...))

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -19,8 +19,9 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 	git := g.NewClient(dir, true)
 
 	org, err := repo.GetOrg("gutenberg")
-	console.ExitIfError(err)
-
+	if err != nil {
+		return pr, err
+	}
 	branch := "rnmobile/release_" + version
 
 	console.Info("Checking if branch %s exists", branch)

--- a/cli/pkg/utils/utils.go
+++ b/cli/pkg/utils/utils.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"regexp"
 	"time"
-
-	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 )
 
 func ValidateVersion(version string) bool {
@@ -41,23 +39,6 @@ func NormalizeVersion(version string) (string, error) {
 		return "", fmt.Errorf("invalid version")
 	}
 	return v, nil
-}
-
-func SetTempDir() (string, error) {
-	tempDir, err := os.MkdirTemp("", "gbm-")
-	if err != nil {
-		return "", err
-	}
-	return tempDir, nil
-}
-
-func CleanupTempDir(tempDir string) error {
-	console.Info("Cleaning up temporary directory %s", tempDir)
-	err := os.RemoveAll(tempDir)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func UpdatePackageVersion(version, path string) error {


### PR DESCRIPTION
Go will not call the deferred function when `os.Exit` is called with a non-zero value.

Currently the command is not cleaning up the temp directories if the run ends with an error.


These changes also move the error handling functions out of the console package. Ideally the console package would not have any side effects which this PR helps achieve. For now, our only entry points to the packages is from the /cmd directory, given that it made sense to move the exit handling functions there.

This PR can be tested as is by running the `release prepare gbm v1.2.3` command while that command is still not implemented. It will create a temporary directory but end in an error. 
It is expected that the temp dir is deleted.