### PR TITLE
Pass pr by value to preview function

### DIFF
--- a/cli/pkg/gh/gh.go
+++ b/cli/pkg/gh/gh.go
@@ -181,7 +181,7 @@ func labelRequest(rpo string, prNum int, labels []string) ([]Label, error) {
 	return resp, nil
 }
 
-func PreviewPr(rpo, dir string, pr *PullRequest) {
+func PreviewPr(rpo, dir string, pr PullRequest) {
 	org, _ := repo.GetOrg(rpo)
 	cyan := color.New(color.FgCyan, color.Bold).SprintfFunc()
 	console.Log(cyan("\nPr Preview"))

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -112,7 +112,7 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 		Name: "Mobile App - i.e. Android or iOS",
 	}}
 
-	gh.PreviewPr("gutenberg", dir, &pr)
+	gh.PreviewPr("gutenberg", dir, pr)
 
 	prompt := fmt.Sprintf("\nReady to create the PR on %s/gutenberg?", org)
 	cont := console.Confirm(prompt)

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -171,7 +171,7 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 	}}
 
 	// Display PR preview
-	gh.PreviewPr("gutenberg-mobile", dir, &pr)
+	gh.PreviewPr("gutenberg-mobile", dir, pr)
 
 	// Add prompt to confirm PR creation
 	prompt := fmt.Sprintf("\nReady to create the PR on %s/gutenberg-mobile?", org)


### PR DESCRIPTION
This should have landed in https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/158

Looks like trunk is broken without this change