### PR TITLE
Add [Type] Build Tooling label to Gutenberg PR prepare command

### DIFF
--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -112,6 +112,10 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 		Name: "Mobile App - i.e. Android or iOS",
 	}}
 
+	pr.Labels = []gh.Label{{
+		Name: "[Type] Build Tooling",
+	}}
+
 	gh.PreviewPr("gutenberg", dir, pr)
 
 	prompt := fmt.Sprintf("\nReady to create the PR on %s/gutenberg?", org)

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -108,13 +108,14 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 		console.Info("Unable to render the GB PR body (err %s)", err)
 	}
 
-	pr.Labels = []gh.Label{{
-		Name: "Mobile App - i.e. Android or iOS",
-	}}
-
-	pr.Labels = []gh.Label{{
-		Name: "[Type] Build Tooling",
-	}}
+	pr.Labels = []gh.Label{
+		{
+			Name: "Mobile App - i.e. Android or iOS",
+		},
+		{
+			Name: "[Type] Build Tooling",
+		},
+	}
 
 	gh.PreviewPr("gutenberg", dir, pr)
 


### PR DESCRIPTION
Adds `[Type] Build Tooling` label to Gutenberg PR prepare command.


* https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/178