### PR TITLE
Add Release Notes and Related Changes when rendering Gutenberg Mobile PR template

### DIFF
--- a/cli/pkg/gh/gh.go
+++ b/cli/pkg/gh/gh.go
@@ -114,6 +114,33 @@ func SearchBranch(rpo, branch string) (Branch, error) {
 	return response, nil
 }
 
+// GetPr returns a PullRequest struct for the given repo and PR number.
+func GetPr(rpo string, id int) (*PullRequest, error) {
+	org, err := repo.GetOrg(rpo)
+	if err != nil {
+		return nil, err
+	}
+	return GetPrOrg(org, rpo, id)
+}
+
+func GetPrOrg(org, repo string, id int) (*PullRequest, error) {
+	client := getClient()
+
+	endpoint := fmt.Sprintf("repos/%s/%s/pulls/%d", org, repo, id)
+	pr := &PullRequest{}
+	if err := client.Get(endpoint, pr); err != nil {
+		return nil, err
+	}
+
+	if pr.Number == 0 {
+		return nil, fmt.Errorf("pr not found %s", endpoint)
+	}
+
+	pr.Repo = repo
+
+	return pr, nil
+}
+
 func SearchPrs(filter RepoFilter) (SearchResult, error) {
 	console.Info("Searching for PRs matching %s", filter.QueryString)
 	client := getClient()

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -46,18 +46,6 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 			return pr, err
 		}
 
-		console.Info("Add remote for %s", org)
-		err = git.AddRemote("upstream", repo.GetRepoPath("gutenberg-mobile"))
-		if err != nil {
-			return pr, err
-		}
-
-		// console.Info("Set upstream to trunk", org)
-		// err = git.SetUpstreamTo("trunk")
-		// if err != nil {
-		// 	return pr, err
-		// }
-
 		console.Info("Checking out branch %s", branch)
 		err = git.Switch("-c", branch)
 		if err != nil {

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -52,11 +52,11 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 			return pr, err
 		}
 
-		console.Info("Set upstream to trunk", org)
-		err = git.SetUpstreamTo("trunk")
-		if err != nil {
-			return pr, err
-		}
+		// console.Info("Set upstream to trunk", org)
+		// err = git.SetUpstreamTo("trunk")
+		// if err != nil {
+		// 	return pr, err
+		// }
 
 		console.Info("Checking out branch %s", branch)
 		err = git.Switch("-c", branch)
@@ -260,15 +260,20 @@ func getChangeLog(dir string, gbmPr *gh.PullRequest) []byte {
 	cl := []byte{}
 
 	if dir == "" {
-		org, _ := repo.GetOrg("gutenberg")
-		endpoint := fmt.Sprintf("https://raw.githubusercontent.com/%s/gutenberg/%s/packages/react-native-editor/CHANGELOG.md", org, gbPr.Head.Sha)
+		console.Warn("not implemented")
 
-		if resp, err := http.Get(endpoint); err != nil {
-			fmt.Errorf("unable to get the changelog (err %s)", err)
-		} else {
-			defer resp.Body.Close()
-			buff = resp.Body
-		}
+		// TODO: find the best way to get the gbPr
+
+		// org, _ := repo.GetOrg("gutenberg")
+		// endpoint := fmt.Sprintf("https://raw.githubusercontent.com/%s/gutenberg/%s/packages/react-native-editor/CHANGELOG.md", org, gbPr.Head.Sha)
+
+		// if resp, err := http.Get(endpoint); err != nil {
+		// 	fmt.Errorf("unable to get the changelog (err %s)", err)
+		// } else {
+		// 	defer resp.Body.Close()
+		// 	buff = resp.Body
+		// }
+		
 	} else {
 		// Read in the change log
 		clPath := filepath.Join(dir, "gutenberg-mobile", "gutenberg", "packages", "react-native-editor", "CHANGELOG.md")

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -206,16 +206,6 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 }
 
 func renderGbmPrBody(version string, pr *gh.PullRequest) error {
-	t := render.Template{
-		Path: "templates/release/gbm_pr_body.md",
-		Data: struct {
-			Version  string
-			GbmPrUrl string
-		}{
-			Version: version,
-		},
-	}
-
 	// TODO - replace "" with dir variable
 	cl := getChangeLog("", pr)
 	rn := getReleaseNotes("", pr)
@@ -236,11 +226,31 @@ func renderGbmPrBody(version string, pr *gh.PullRequest) error {
 	if err != nil {
 		console.Error(err)
 	}
+	
+	prs := []gh.PullRequest{}
+	for _, s := range synced {
+		prs = append(prs, s.Items...)
+	}
+
+	t := render.Template{
+		Path: "templates/release/gbm_pr_body.md",
+		Data: struct {
+			Version  string
+			GbmPrUrl string
+			Changes    []ReleaseChanges
+			RelatedPRs []gh.PullRequest
+		}{
+			Version:    version,
+			Changes:    rc,
+			RelatedPRs: prs,
+		},
+	}
 
 	body, err := render.Render(t)
 	if err != nil {
 		return err
 	}
+
 	pr.Body = body
 	return nil
 }

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -215,8 +215,27 @@ func renderGbmPrBody(version string, pr *gh.PullRequest) error {
 			Version: version,
 		},
 	}
-	cl := getChangeLog(dir, pr)
-	rn := getReleaseNotes(dir, pr)
+
+	// TODO - replace "" with dir variable
+	cl := getChangeLog("", pr)
+	rn := getReleaseNotes("", pr)
+
+	rc, err := CollectReleaseChanges(version, cl, rn)
+
+	if err != nil {
+		console.Error(err)
+	}
+
+	rfs := []gh.RepoFilter{
+		gh.BuildRepoFilter("gutenberg", "is:open", "is:pr", `label:"Mobile App - i.e. Android or iOS"`, fmt.Sprintf("v%s in:title", version)),
+		gh.BuildRepoFilter("WordPress-Android", "is:open", "is:pr", version+" in:title"),
+		gh.BuildRepoFilter("WordPress-iOS", "is:open", "is:pr", version+" in:title"),
+	}	
+
+	synced, err := gh.FindGbmSyncedPrs(*pr, rfs)
+	if err != nil {
+		console.Error(err)
+	}
 
 	body, err := render.Render(t)
 	if err != nil {

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -98,7 +98,7 @@ func CollectReleaseChanges(version string, changelog, relnotes []byte) ([]Releas
 					PrUrl:  pr.Url,
 					Number: pr.Number,
 				}
-				// checkPRforIssues(*pr, &rc)
+				checkPRforIssues(*pr, &rc)
 				prs = append(prs, rc)
 			}
 		}
@@ -130,11 +130,21 @@ func CollectReleaseChanges(version string, changelog, relnotes []byte) ([]Releas
 					PrUrl:  pr.Url,
 					Number: pr.Number,
 				}
-				// checkPRforIssues(*pr, &rc)
+				checkPRforIssues(*pr, &rc)
 				prs = append(prs, rc)
 
 			}
 		}
 	}
 	return prs, nil
+}
+
+func checkPRforIssues(pr gh.PullRequest, rc *ReleaseChanges) {
+	issueRe := regexp.MustCompile(`(https:\/\/github.com\/.*\/.*\/issues\/\d*)`)
+
+	matches := issueRe.FindAllStringSubmatch(pr.Body, -1)
+
+	for _, m := range matches {
+		rc.Issues = append(rc.Issues, m[1])
+	}
 }

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -2,7 +2,12 @@ package release
 
 import (
 	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 
+	"github.com/wordpress-mobile/gbm-cli/internal/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
 	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
 )
@@ -22,4 +27,114 @@ func updatePackageJson(dir, version string, pkgs ...string) error {
 	}
 
 	return nil
+}
+
+type ReleaseChanges struct {
+	Title  string
+	Number int
+	PrUrl  string
+	Issues []string
+}
+
+func CollectReleaseChanges(version string, changelog, relnotes []byte) ([]ReleaseChanges, error) {
+	changesRe := regexp.MustCompile(`(?s)\d+\.\d+\.\d+(.*?)\d+\.\d+\.\d+`)
+	// rnChangesRe := regexp.MustCompile(`(?s)\d+\.\d+\.\d+(.*?)\d+\.\d+\.\d+`)
+	prNumbRe := regexp.MustCompile(`\[#(\d+)\]`)
+	prOrgRepoNumRe := regexp.MustCompile(`https://github\.com/(\w+)/(\w+)/pull/(\d+)`)
+	bracketRe := regexp.MustCompile(`\[.*\]\s*-*`)
+
+	prs := []ReleaseChanges{}
+
+	prFoundAlready := func(num int) bool {
+		for _, p := range prs {
+			if p.Number == num {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Get the changes from the Release notes
+	match := changesRe.Find(relnotes)
+	if match != nil {
+
+		lines := strings.Split(string(match), "\n")
+
+		for _, l := range lines {
+			// first check for any prs relative to gutenberg-mobile
+			matches := prNumbRe.FindAllStringSubmatch(l, -1)
+
+			if len(matches) == 1 {
+
+				prId, _ := strconv.Atoi(matches[0][1])
+
+				pr, err := gh.GetPr("gutenberg", prId)
+				if err != nil {
+					console.Warn("There was an issue fetching a gutenberg pr #%d", prId)
+					continue
+				}
+				// Scrub [] from title
+				title := bracketRe.ReplaceAllString(pr.Title, "")
+				prs = append(prs, ReleaseChanges{Title: title, PrUrl: pr.Url, Number: pr.Number})
+			}
+
+			// now look for urls
+			matches = prOrgRepoNumRe.FindAllStringSubmatch(l, -1)
+			if len(matches) != 0 {
+				match := matches[0]
+				org := match[1]
+				rep := match[2]
+				num := match[3]
+				prId, _ := strconv.Atoi(num)
+				pr, err := gh.GetPrOrg(org, rep, prId)
+				if err != nil {
+					console.Warn("There was an issue fetching %s/%s/pull/%d", org, rep, prId)
+					continue
+				}
+				// Scrub [] from title
+				title := bracketRe.ReplaceAllString(pr.Title, "")
+				rc := ReleaseChanges{
+					Title:  title,
+					PrUrl:  pr.Url,
+					Number: pr.Number,
+				}
+				// checkPRforIssues(*pr, &rc)
+				prs = append(prs, rc)
+			}
+		}
+	}
+	// Get changes from the Change log
+	match = changesRe.Find(changelog)
+
+	if match != nil {
+		lines := strings.Split(string(match), "\n")
+
+		for _, l := range lines {
+
+			match := prNumbRe.FindAllStringSubmatch(l, -1)
+
+			if len(match) == 1 {
+				prId, _ := strconv.Atoi(match[0][1])
+				if prFoundAlready(prId) {
+					continue
+				}
+				pr, err := gh.GetPrOrg("WordPress", "gutenberg", prId)
+				if err != nil {
+					console.Warn("There was an issue fetching a gutenberg pr #%d", prId)
+					continue
+				}
+
+				title := bracketRe.ReplaceAllString(pr.Title, "")
+				rc := ReleaseChanges{
+					Title:  title,
+					PrUrl:  pr.Url,
+					Number: pr.Number,
+				}
+				// checkPRforIssues(*pr, &rc)
+				prs = append(prs, rc)
+
+			}
+		}
+	}
+	return prs, nil
 }

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wordpress-mobile/gbm-cli/internal/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
 	"github.com/wordpress-mobile/gbm-cli/pkg/utils"


### PR DESCRIPTION
Adds Release Notes and Related Changes when rendering Gutenberg Mobile PR template, including associated utils.

Based on previous examples of [getChangeLog](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/gbm-cli/cli/pkg/release/gbm.go#L159) and [getReleaseNotes](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/gbm-cli/cli/pkg/release/gbm.go#L199) to work with the [updated GBM PR template](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/gbm-cli/cli/templates/release/gbmPrBody.md) and ported to new utils/structure when necessary. 

#### To test:
From the `cli` directory, run the following against project repos forked to a workspace, e.g.:

```
GBM_WPMOBILE_ORG=derekblank GBM_WORDPRESS_ORG=derekblank go run main.go release prepare gbm 1.12.0
```

#### Todos to discuss:

- [x] **Passing `dir` to the get functions**: https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/183/files#r1366518576
- [x] **Getting `gbPr.Head.Sha` in the render function**: https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/183/files#r1366519773