### PR TITLE
Cli: Add 'prepare all' command 

### DIFF
--- a/cli/cmd/release/integrate.go
+++ b/cli/cmd/release/integrate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
+	wp "github.com/wordpress-mobile/gbm-cli/cmd/workspace"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release/integrate"
@@ -84,6 +85,17 @@ var IntegrateCmd = &cobra.Command{
 }
 
 func init() {
+	var err error
+	workspace, err = wp.NewWorkspace()
+	utils.ExitIfError(err, 1)
+
+	exitIfError = func(err error, code int) {
+		if err != nil {
+			console.Error(err)
+			utils.Exit(code, workspace.Cleanup)
+		}
+	}
+	tempDir = workspace.Dir()
 	IntegrateCmd.Flags().BoolVarP(&android, "android", "a", false, "Only integrate Android")
 	IntegrateCmd.Flags().BoolVarP(&ios, "ios", "i", false, "Only integrate iOS")
 }

--- a/cli/cmd/release/prepare/all.go
+++ b/cli/cmd/release/prepare/all.go
@@ -1,0 +1,46 @@
+package prepare
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
+)
+
+var allCmd = &cobra.Command{
+	Use:   "all",
+	Short: "Prepare Gutenberg and Gutenberg Mobile for a mobile release",
+	Long:  `Use this command to prepare a Gutenberg and Gutenberg Mobile release PRs`,
+	Run: func(cc *cobra.Command, args []string) {
+		preflight(args)
+		var err error
+
+		// Set up separate directories for each repo
+		gbDir := filepath.Join(tempDir, "gb")
+		err = os.MkdirAll(gbDir, os.ModePerm)
+		exitIfError(err, 1)
+
+		gbmDir := filepath.Join(tempDir, "gbm")
+		err = os.MkdirAll(gbmDir, os.ModePerm)
+		exitIfError(err, 1)
+
+		gbPr := gh.PullRequest{}
+
+		console.Info("Preparing Gutenberg for release %s", version)
+
+		gbPr, err = release.CreateGbPR(version, gbDir)
+		exitIfError(err, 1)
+		console.Info("Finished preparing Gutenberg PR")
+
+		console.Info("Preparing Gutenberg Mobile for release %s", version)
+
+		pr, err := release.CreateGbmPR(version, gbmDir)
+		exitIfError(err, 1)
+		console.Info("Finished preparing Gutenberg Mobile PR")
+
+		console.Info("\nFinished preparing PRs:\n%s\n%s", gbPr.Url, pr.Url)
+	},
+}

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -1,12 +1,8 @@
 package prepare
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
-	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 )
 
@@ -15,14 +11,7 @@ var gbCmd = &cobra.Command{
 	Short: "Prepare Gutenberg for a mobile release",
 	Long:  `Use this command to prepare a Gutenberg release PR`,
 	Run: func(cc *cobra.Command, args []string) {
-		tempDir := workspace.Dir()
-		version, err := utils.GetVersionArg(args)
-		exitIfError(err, 1)
-
-		// Validate Aztec version
-		if valid := gbm.ValidateAztecVersions(); !valid {
-			exitIfError(errors.New("invalid Aztec versions found"), 1)
-		}
+		preflight(args)
 
 		console.Info("Preparing Gutenberg for release %s", version)
 

--- a/cli/cmd/release/prepare/gbm.go
+++ b/cli/cmd/release/prepare/gbm.go
@@ -1,12 +1,8 @@
 package prepare
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
-	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 )
 
@@ -15,14 +11,7 @@ var gbmCmd = &cobra.Command{
 	Short: "Prepare Gutenberg Mobile release",
 	Long:  `Use this command to prepare a Gutenberg Mobile release PR`,
 	Run: func(cmd *cobra.Command, args []string) {
-		tempDir := workspace.Dir()
-		version, err := utils.GetVersionArg(args)
-		exitIfError(err, 1)
-
-		// Validate Aztec version
-		if valid := gbm.ValidateAztecVersions(); !valid {
-			exitIfError(errors.New("the Aztec versions are not valid"), 1)
-		}
+		preflight(args)
 
 		console.Info("Preparing Gutenberg Mobile for release %s", version)
 

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -1,14 +1,19 @@
 package prepare
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	wp "github.com/wordpress-mobile/gbm-cli/cmd/workspace"
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 )
 
 var exitIfError func(error, int)
 var keepTempDir bool
 var workspace wp.Workspace
+var tempDir, version string
 
 var PrepareCmd = &cobra.Command{
 	Use:   "prepare",
@@ -24,13 +29,29 @@ func Execute() {
 	defer workspace.Cleanup()
 }
 
+// Set up the temp directory and version
+// Also validate Aztec versions
+func preflight(args []string) {
+	var err error
+	tempDir = workspace.Dir()
+	version, err = utils.GetVersionArg(args)
+	exitIfError(err, 1)
+
+	// Validate Aztec version
+	if valid := gbm.ValidateAztecVersions(); !valid {
+		exitIfError(errors.New("invalid Aztec versions found"), 1)
+	}
+}
+
 func init() {
 	var err error
 	workspace, err = wp.NewWorkspace()
 	utils.ExitIfError(err, 1)
 
 	exitIfError = func(err error, code int) {
+
 		if err != nil {
+			console.Error(err)
 			utils.Exit(code, workspace.Cleanup)
 		}
 	}

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -58,5 +58,6 @@ func init() {
 
 	PrepareCmd.AddCommand(gbmCmd)
 	PrepareCmd.AddCommand(gbCmd)
+	PrepareCmd.AddCommand(allCmd)
 	PrepareCmd.PersistentFlags().BoolVar(&keepTempDir, "k", false, "Keep temporary directory after running command")
 }

--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -3,7 +3,6 @@ package release
 import (
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/cmd/release/prepare"
-	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	wp "github.com/wordpress-mobile/gbm-cli/cmd/workspace"
 )
 
@@ -29,16 +28,7 @@ func Execute() {
 }
 
 func init() {
-	var err error
-	workspace, err = wp.NewWorkspace()
-	utils.ExitIfError(err, 1)
 
-	exitIfError = func(err error, code int) {
-		if err != nil {
-			utils.Exit(code, workspace.Cleanup)
-		}
-	}
-	tempDir = workspace.Dir()
 	ReleaseCmd.AddCommand(prepare.PrepareCmd)
 	ReleaseCmd.AddCommand(IntegrateCmd)
 	ReleaseCmd.AddCommand(StatusCmd)

--- a/cli/cmd/release/status.go
+++ b/cli/cmd/release/status.go
@@ -5,6 +5,8 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 )
 
 var StatusCmd = &cobra.Command{
@@ -15,13 +17,55 @@ var StatusCmd = &cobra.Command{
 		version, err := utils.GetVersionArg(args)
 		exitIfError(err, 1)
 
-		// Get the GBM Pr
-		pr, err := gbm.FindGbmReleasePr(version)
+		// Print styles
+		heading := console.Heading
+		headingRow := console.HeadingRow
+		row := console.Row
+
+		console.Print(heading, "\nRelease %s Status\n", version)
+
+		prs := []gh.PullRequest{}
+		gbPr, gbmPr, androidPr, iosPr := gh.PullRequest{}, gh.PullRequest{}, gh.PullRequest{}, gh.PullRequest{}
+
+		// @TODO: search for gb pr
+		gbPr.Repo = repo.GetOrg("gutenberg") + "/gutenberg"
+		prs = append(prs, gbPr)
+
+		gbmPr, err = gbm.FindGbmReleasePr(version)
 		exitIfError(err, 1)
-		console.Info("Checking: %s", pr.Title)
+		gbmPr.Repo = repo.GetOrg("gutenberg-mobile") + "/gutenberg-mobile"
+		prs = append(prs, gbmPr)
+
+		androidPr, err = gbm.FindAndroidReleasePr(version)
+		exitIfError(err, 1)
+		androidPr.Repo = repo.GetOrg("WordPress-Android") + "/WordPress-Android"
+		prs = append(prs, androidPr)
+
+		iosPr, err = gbm.FindIosReleasePr(version)
+		exitIfError(err, 1)
+		iosPr.Repo = repo.GetOrg("WordPress-iOS") + "/WordPress-iOS"
+		prs = append(prs, iosPr)
+
+		console.Print(heading, "Release Prs:")
+		console.Print(headingRow, "%-27s %-10s %-10v %s", "Repo", "State", "Mergeable", "Url")
+
+		// List the PRs
+		for _, pr := range prs {
+			if pr.Number == 0 {
+				pr.State = "…"
+				pr.Url = "…"
+			}
+			console.Print(row, "• %-25s %-10s %-10v %s", pr.Repo, pr.State, pr.Mergeable, pr.Url)
+		}
 
 		// Get the status for the head sha
-		sha := pr.Head.Sha
+
+		console.Print(heading, "\nGutenberg Mobile Build Status")
+		if gbmPr.Number == 0 {
+			console.Info("...Waiting for Gutenberg Mobile PR to be created before checking build status")
+			return
+		}
+		sha := gbmPr.Head.Sha
 		console.Info("Getting Gutenberg Builds for sha: %s", sha)
 		exitIfError(err, 1)
 

--- a/cli/pkg/console/console.go
+++ b/cli/pkg/console/console.go
@@ -13,11 +13,17 @@ import (
 )
 
 var (
-	l *log.Logger
+	l          *log.Logger
+	Heading    *color.Color
+	HeadingRow *color.Color
+	Row        *color.Color
 )
 
 func init() {
 	l = log.New(os.Stderr, "", 0)
+	Heading = color.New(color.FgWhite, color.Bold)
+	HeadingRow = color.New(color.FgGreen, color.Bold)
+	Row = color.New(color.FgGreen)
 }
 
 // Deprecated
@@ -73,6 +79,12 @@ func Log(format string, args ...interface{}) {
 func Debug(format string, args ...interface{}) {
 	blue := color.New(color.FgBlue).SprintfFunc()
 	l.Printf(blue("\n"+format, args...))
+	color.Unset()
+}
+
+func Print(c *color.Color, format string, args ...interface{}) {
+	styled := c.SprintfFunc()
+	l.Printf(styled(format, args...))
 	color.Unset()
 }
 

--- a/cli/pkg/gbm/search.go
+++ b/cli/pkg/gbm/search.go
@@ -11,7 +11,7 @@ func FindGbmReleasePr(version string) (gh.PullRequest, error) {
 	label := fmt.Sprintf("label:%s", GbmReleasePrLabel)
 	title := fmt.Sprintf("%s in:title", version)
 
-	filter := gh.BuildRepoFilter(repo.GutenbergMobileRepo, "is:pr", label, title)
+	filter := gh.BuildRepoFilter(repo.GutenbergMobileRepo, "is:pr", "is:open", label, title)
 	pr, err := gh.SearchPr(filter)
 	if err != nil {
 		return gh.PullRequest{}, err

--- a/cli/pkg/gh/gh.go
+++ b/cli/pkg/gh/gh.go
@@ -93,7 +93,7 @@ type Status struct {
 
 // Build a RepoFilter from a repo name and a list of queries.
 func BuildRepoFilter(rpo string, queries ...string) RepoFilter {
-	org, _ := repo.GetOrg(rpo)
+	org := repo.GetOrg(rpo)
 
 	var encoded []string
 	queries = append(queries, fmt.Sprintf("repo:%s/%s", org, rpo))
@@ -113,9 +113,9 @@ func BuildRepoFilter(rpo string, queries ...string) RepoFilter {
 
 // SearchBranch returns a branch for the given repo and branch name.
 func SearchBranch(rpo, branch string) (Branch, error) {
-	org, err := repo.GetOrg(rpo)
-	if err != nil {
-		return Branch{}, err
+	org := repo.GetOrg(rpo)
+	if org == "" {
+		return Branch{}, fmt.Errorf("unable to get org for %s", rpo)
 	}
 	response := Branch{}
 	client := getClient()
@@ -184,9 +184,9 @@ func GetPrOrg(org, repo string, id int) (*PullRequest, error) {
 
 func GetPr(rpo string, number int) (PullRequest, error) {
 	pr := PullRequest{}
-	org, err := repo.GetOrg(rpo)
-	if err != nil {
-		return pr, err
+	org := repo.GetOrg(rpo)
+	if org == "" {
+		return pr, fmt.Errorf("unable to get org for %s", rpo)
 	}
 
 	client := getClient()
@@ -200,10 +200,7 @@ func GetPr(rpo string, number int) (PullRequest, error) {
 
 func CreatePr(rpo string, pr *PullRequest) error {
 	client := getClient()
-	org, err := repo.GetOrg(rpo)
-	if err != nil {
-		return err
-	}
+	org := repo.GetOrg(rpo)
 
 	labels := pr.Labels
 	endpoint := fmt.Sprintf("repos/%s/%s/pulls", org, rpo)
@@ -264,10 +261,7 @@ func AddLabels(repo string, pr *PullRequest) error {
 }
 
 func GetStatusChecks(rpo, sha string) (Status, error) {
-	org, err := repo.GetOrg(rpo)
-	if err != nil {
-		return Status{}, err
-	}
+	org := repo.GetOrg(rpo)
 
 	client := getClient()
 	endpoint := fmt.Sprintf("repos/%s/%s/commits/%s/status", org, rpo, sha)
@@ -315,10 +309,7 @@ func getClient() *api.RESTClient {
 }
 
 func labelRequest(rpo string, prNum int, labels []string) ([]Label, error) {
-	org, err := repo.GetOrg(rpo)
-	if err != nil {
-		return nil, err
-	}
+	org := repo.GetOrg(rpo)
 
 	client := getClient()
 
@@ -344,7 +335,7 @@ func labelRequest(rpo string, prNum int, labels []string) ([]Label, error) {
 }
 
 func PreviewPr(rpo, dir string, pr PullRequest) {
-	org, _ := repo.GetOrg(rpo)
+	org := repo.GetOrg(rpo)
 	cyan := color.New(color.FgCyan, color.Bold).SprintfFunc()
 	console.Log(cyan("\nPr Preview"))
 	console.Log(cyan("Local:")+" %s\n", dir)

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -20,10 +20,7 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 	shellProps := shell.CmdProps{Dir: dir, Verbose: true}
 	git := shell.NewGitCmd(shellProps)
 
-	org, err := repo.GetOrg("gutenberg")
-	if err != nil {
-		return pr, err
-	}
+	org := repo.GetOrg("gutenberg")
 	branch := "rnmobile/release_" + version
 
 	exists, _ := gh.SearchBranch("gutenberg", branch)

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -1,7 +1,6 @@
 package release
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -32,9 +31,9 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 
 		if !cont {
 			console.Info("Bye 👋")
-			return pr, fmt.Errorf("exiting before creating PR: %v", err)
+			return pr, fmt.Errorf("exiting before creating PR")
 		}
-
+		return pr, fmt.Errorf("existing branch not implemented yet")
 	} else {
 		console.Info("Cloning Gutenberg to %s", dir)
 
@@ -44,8 +43,6 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 		if err != nil {
 			return pr, fmt.Errorf("error cloning the Gutenberg repository: %v", err)
 		}
-
-		exitIfError(errors.New("not implemented"), 1)
 
 		console.Info("Checking out branch %s", branch)
 		err = git.Switch("-c", branch)
@@ -142,7 +139,7 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 	}
 
 	if pr.Number == 0 {
-		return pr, fmt.Errorf("error creating the PR: %v", err)
+		return pr, fmt.Errorf("pr was not created successfully")
 	}
 
 	return pr, nil

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -241,10 +241,12 @@ func renderGbmPrBody(version string, pr *gh.PullRequest) error {
 
 func getChangeLog(dir string, gbmPr *gh.PullRequest) []byte {
 	var buff io.ReadCloser
+	defer buff.Close()
 	cl := []byte{}
 
 	if dir == "" {
 		console.Warn("not implemented")
+		return cl
 
 		// TODO: find the best way to get the gbPr
 

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -24,8 +24,7 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 	git := shell.NewGitCmd(sp)
 
 	// Set Gutenberg Mobile repository and org
-	org, err := repo.GetOrg("gutenberg-mobile")
-	console.ExitIfError(err)
+	org := repo.GetOrg("gutenberg-mobile")
 
 	// Set Gutenberg Mobile branch name e.g., (release/x.xx.x)
 	branch := "release/" + version
@@ -284,7 +283,7 @@ func getReleaseNotes(dir string, gbmPr *gh.PullRequest) []byte {
 	rn := []byte{}
 
 	if dir == "" {
-		org, _ := repo.GetOrg("gutenberg-mobile")
+		org := repo.GetOrg("gutenberg-mobile")
 		endpoint := fmt.Sprintf("https://raw.githubusercontent.com/%s/gutenberg-mobile/%s/RELEASE-NOTES.txt", org, gbmPr.Head.Sha)
 
 		if resp, err := http.Get(endpoint); err != nil {

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -191,8 +191,14 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 
 func renderGbmPrBody(version string, pr *gh.PullRequest) error {
 	// TODO - replace "" with dir variable
-	cl := getChangeLog("", pr)
-	rn := getReleaseNotes("", pr)
+	cl, err := getChangeLog("", pr)
+	if err != nil {
+		console.Warn(err.Error())
+	}
+	rn, err := getReleaseNotes("", pr)
+	if err != nil {
+		console.Warn(err.Error())
+	}
 
 	rc, err := CollectReleaseChanges(version, cl, rn)
 
@@ -204,13 +210,13 @@ func renderGbmPrBody(version string, pr *gh.PullRequest) error {
 		gh.BuildRepoFilter("gutenberg", "is:open", "is:pr", `label:"Mobile App - i.e. Android or iOS"`, fmt.Sprintf("v%s in:title", version)),
 		gh.BuildRepoFilter("WordPress-Android", "is:open", "is:pr", version+" in:title"),
 		gh.BuildRepoFilter("WordPress-iOS", "is:open", "is:pr", version+" in:title"),
-	}	
+	}
 
 	synced, err := gh.FindGbmSyncedPrs(*pr, rfs)
 	if err != nil {
 		console.Error(err)
 	}
-	
+
 	prs := []gh.PullRequest{}
 	for _, s := range synced {
 		prs = append(prs, s.Items...)
@@ -219,8 +225,8 @@ func renderGbmPrBody(version string, pr *gh.PullRequest) error {
 	t := render.Template{
 		Path: "templates/release/gbm_pr_body.md",
 		Data: struct {
-			Version  string
-			GbmPrUrl string
+			Version    string
+			GbmPrUrl   string
 			Changes    []ReleaseChanges
 			RelatedPRs []gh.PullRequest
 		}{
@@ -239,14 +245,13 @@ func renderGbmPrBody(version string, pr *gh.PullRequest) error {
 	return nil
 }
 
-func getChangeLog(dir string, gbmPr *gh.PullRequest) []byte {
+func getChangeLog(dir string, gbmPr *gh.PullRequest) ([]byte, error) {
 	var buff io.ReadCloser
-	defer buff.Close()
 	cl := []byte{}
 
 	if dir == "" {
 		console.Warn("not implemented")
-		return cl
+		return cl, nil
 
 		// TODO: find the best way to get the gbPr
 
@@ -259,28 +264,28 @@ func getChangeLog(dir string, gbmPr *gh.PullRequest) []byte {
 		// 	defer resp.Body.Close()
 		// 	buff = resp.Body
 		// }
-		
+
 	} else {
 		// Read in the change log
 		clPath := filepath.Join(dir, "gutenberg-mobile", "gutenberg", "packages", "react-native-editor", "CHANGELOG.md")
 		if clf, err := os.Open(clPath); err != nil {
-			fmt.Errorf("unable to open the changelog %s", err)
+			return cl, fmt.Errorf("unable to open the changelog %s", err)
 		} else {
 			defer clf.Close()
 			buff = clf
-
 		}
 	}
+
 	if data, err := io.ReadAll(buff); err != nil {
-		fmt.Errorf("unable to read the changelog %s", err)
+		return cl, fmt.Errorf("unable to read the changelog %s", err)
 	} else {
 		cl = data
 	}
 
-	return cl
+	return cl, nil
 }
 
-func getReleaseNotes(dir string, gbmPr *gh.PullRequest) []byte {
+func getReleaseNotes(dir string, gbmPr *gh.PullRequest) ([]byte, error) {
 	var buff io.ReadCloser
 	rn := []byte{}
 
@@ -289,7 +294,7 @@ func getReleaseNotes(dir string, gbmPr *gh.PullRequest) []byte {
 		endpoint := fmt.Sprintf("https://raw.githubusercontent.com/%s/gutenberg-mobile/%s/RELEASE-NOTES.txt", org, gbmPr.Head.Sha)
 
 		if resp, err := http.Get(endpoint); err != nil {
-			fmt.Errorf("unable to get the changelog (err %s)", err)
+			return rn, fmt.Errorf("unable to get the changelog (err %s)", err)
 		} else {
 			defer resp.Body.Close()
 			buff = resp.Body
@@ -299,17 +304,17 @@ func getReleaseNotes(dir string, gbmPr *gh.PullRequest) []byte {
 		rnPath := filepath.Join(dir, "gutenberg-mobile", "RELEASE-NOTES.txt")
 
 		if rnf, err := os.Open(rnPath); err != nil {
-			fmt.Errorf("unable to open the release notes %s", err)
+			return rn, fmt.Errorf("unable to open the release notes %s", err)
 		} else {
 			defer rnf.Close()
 			buff = rnf
 		}
 	}
 	if data, err := io.ReadAll(buff); err != nil {
-		fmt.Errorf("unable to read the release notes %s", err)
+		return rn, fmt.Errorf("unable to read the release notes %s", err)
 	} else {
 		rn = data
 	}
 
-	return rn
+	return rn, nil
 }

--- a/cli/pkg/release/integrate/integrate.go
+++ b/cli/pkg/release/integrate/integrate.go
@@ -38,7 +38,7 @@ type Target interface {
 
 func (ri *ReleaseIntegration) Run(dir string) (gh.PullRequest, error) {
 	rpo := ri.Target.GetRepo()
-	org, _ := repo.GetOrg(rpo)
+	org := repo.GetOrg(rpo)
 
 	// Check if the GBM build is published
 	// Only if the target is wordpress-mobile

--- a/cli/pkg/repo/repo.go
+++ b/cli/pkg/repo/repo.go
@@ -41,24 +41,24 @@ func InitOrgs() {
 	}
 }
 
-func GetOrg(repo string) (string, error) {
+func GetOrg(repo string) string {
 	switch repo {
 	case GutenbergRepo:
-		return WordPressOrg, nil
+		return WordPressOrg
 	case JetpackRepo:
-		return AutomatticOrg, nil
+		return AutomatticOrg
 	case GutenbergMobileRepo:
 		fallthrough
 	case WordPressAndroidRepo:
 		fallthrough
 	case WordPressIosRepo:
-		return WpMobileOrg, nil
+		return WpMobileOrg
 	default:
-		return "", fmt.Errorf("unknown repo: %s", repo)
+		return ""
 	}
 }
 
 func GetRepoPath(repo string) string {
-	org, _ := GetOrg(repo)
+	org := GetOrg(repo)
 	return fmt.Sprintf("git@github.com:%s/%s", org, repo)
 }


### PR DESCRIPTION
Fixes #187 
Adds a `release prepare all` command which runs both gb and gbm prepare commands.
This can be used to replicate most of the current release script.

This change set also includes a few other minor updates:
- Add more info to the status command
- Remove redundant error return from `repo.getOrg` calls. (most of the errors are assigned to `_`)
- Fix a couple of nil pointer issues in the `release/gbm` package.