### PR TITLE
Cli/fix integrate

### DIFF
--- a/cli/cmd/release/integrate.go
+++ b/cli/cmd/release/integrate.go
@@ -39,20 +39,24 @@ var IntegrateCmd = &cobra.Command{
 			target := integrate.AndroidIntegration{}
 			androidRi.Target = target
 			pr, err := androidRi.Run(filepath.Join(tempDir, "android"))
-			console.Warn(err.Error())
+			if err != nil {
+				console.Warn(err.Error())
+			}
 			results = append(results, pr)
 		}
 
 		createIosPr := func() {
 			iosDir := filepath.Join(tempDir, "ios")
-			err = os.MkdirAll(iosDir, os.ModePerm)
+			err := os.MkdirAll(iosDir, os.ModePerm)
 			exitIfError(err, 1)
 
 			iosRi := ri
 			target := integrate.IosIntegration{}
 			iosRi.Target = target
 			pr, err := iosRi.Run(filepath.Join(tempDir, "ios"))
-			console.Warn(err.Error())
+			if err != nil {
+				console.Warn(err.Error())
+			}
 			results = append(results, pr)
 		}
 

--- a/cli/pkg/release/integrate/android.go
+++ b/cli/pkg/release/integrate/android.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
 )
 
@@ -42,16 +43,15 @@ func (ai AndroidIntegration) UpdateGutenbergConfig(dir string, gbmPr gh.PullRequ
 	return git.CommitAll("Release script: Update build.gradle gutenbergMobileVersion to ref")
 }
 
-func (ia AndroidIntegration) GetRepo() string {
-	return "foobar"
-	// return repo.WordPressAndroidRepo
+func (ai AndroidIntegration) GetRepo() string {
+	return repo.WordPressAndroidRepo
 }
 
-func (ia AndroidIntegration) GetPr(version string) (gh.PullRequest, error) {
+func (ai AndroidIntegration) GetPr(version string) (gh.PullRequest, error) {
 	return gbm.FindAndroidReleasePr(version)
 }
 
-func (ia AndroidIntegration) GbPublished(version string) (bool, error) {
+func (ai AndroidIntegration) GbPublished(version string) (bool, error) {
 	published, err := gbm.AndroidGbmBuildPublished(version)
 	if err != nil {
 		console.Warn("Error checking if GBM build is published: %v", err)

--- a/cli/pkg/release/integrate/integrate.go
+++ b/cli/pkg/release/integrate/integrate.go
@@ -74,15 +74,6 @@ func (ri *ReleaseIntegration) Run(dir string) (gh.PullRequest, error) {
 		return pr, fmt.Errorf("error updating the gutenberg config: %v", err)
 	}
 
-	if !ri.Ci {
-		// Check if we want to continue before pushing
-		prompt := fmt.Sprintf("\nReady to push changes to %s/%s?", org, rpo)
-		if cont := console.Confirm(prompt); !cont {
-			console.Info("Bye 👋")
-			return pr, errors.New("exiting before pushing changes")
-		}
-	}
-
 	if err := git.Push(); err != nil {
 		return pr, fmt.Errorf("error pushing changes: %v", err)
 	}

--- a/cli/pkg/release/integrate/ios.go
+++ b/cli/pkg/release/integrate/ios.go
@@ -54,7 +54,7 @@ func (ii IosIntegration) UpdateGutenbergConfig(dir string, gbmPr gh.PullRequest)
 		return err
 	}
 
-	return git.CommitAll("Release script: Update gutenberg-mobile ref", version)
+	return git.CommitAll("Release script: Update gutenberg-mobile ref %s", version)
 }
 
 func (ii IosIntegration) GetRepo() string {


### PR DESCRIPTION
A few small fixes to the `release integrate` command:
- Fix a few nil error objects
- Fix some leftover debugging setups
- Remove redundant confirm