### PR TITLE
Add missing checklist step to Release Checklist template

### DIFF
--- a/cli/cmd/README.md
+++ b/cli/cmd/README.md
@@ -3,4 +3,4 @@
 This directory contains the available CLI subcommands, organized in the [recommended command structure](https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#organizing-subcommands) from `cobra`.
 
 ### Commands
-- [`render`](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/gbm-cli/cli/README.md)
+- [`render`](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/trunk/cli/cmd/render/README.md)

--- a/cli/templates/checklist/checklist.html
+++ b/cli/templates/checklist/checklist.html
@@ -130,11 +130,11 @@ and don't forget to run <code>npm run bundle</code> in gutenberg-mobile again if
 {{ Task `Navigate to the Buildkite job that built the JS bundles (<code>Build JS Bundles</code>) for the published tag. Open the job and navigate to the "Artifacts" tab. Locate the composed source maps (they have file name <code>bundle/{platform}/App.composed.js.map</code>) and download them.` }}
 <!-- wp:list -->
 <ul><!-- wp:list-item -->
-<li>File: <code><code>bundle/android/App.composed.js.map</code></code> – Artifact name: <code>android-App.js.map</code></li>
+<li>File: <code>bundle/android/App.composed.js.map</code> – Artifact name: <code>android-App.js.map</code></li>
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li>File: <code><code>bundle/ios/App.composed.js.map</code></code> – Artifact name: <code>ios-App.js.map</code></li>
+<li>File: <code>bundle/ios/App.composed.js.map</code> – Artifact name: <code>ios-App.js.map</code></li>
 <!-- /wp:list-item --></ul>
 
 <!-- /wp:list --></div>

--- a/cli/templates/checklist/checklist.html
+++ b/cli/templates/checklist/checklist.html
@@ -125,9 +125,11 @@ and don't forget to run <code>npm run bundle</code> in gutenberg-mobile again if
 
 {{ Task `Wait until all CI jobs for the published tag finish and succeed.` }}
 
+{{ Task `Navigate to the Buildkite job that built the JS bundles (<code>Build JS Bundles</code>) for the published tag. Open the job and navigate to the "Artifacts" tab. Locate the composed source maps (they have file name <code>bundle/{platform}/App.composed.js.map</code>) and download them.` }}
+
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
-{{ Task `Navigate to the Buildkite job that built the JS bundles (<code>Build JS Bundles</code>) for the published tag. Open the job and navigate to the "Artifacts" tab. Locate the composed source maps (they have file name <code>bundle/{platform}/App.composed.js.map</code>) and download them.` }}
+{{ Task `Navigate and edit the GitHub release. Attach the composed source maps to the release (you can drag and drop the files in the “Attach binaries” drop area). Once they are uploaded, update the artifact’s name following this format:` }}
 <!-- wp:list -->
 <ul><!-- wp:list-item -->
 <li>File: <code>bundle/android/App.composed.js.map</code> – Artifact name: <code>android-App.js.map</code></li>


### PR DESCRIPTION
Add missing checklist step to Release Checklist template:

```
Task `Navigate and edit the GitHub release. Attach the composed source maps to the release (you can drag and drop the files in the “Attach binaries” drop area). Once they are uploaded, update the artifact’s name following this format:
```

* https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/165