### PR TITLE
Cli/integrate targets

### DIFF
--- a/cli/cmd/release/integrate.go
+++ b/cli/cmd/release/integrate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	wp "github.com/wordpress-mobile/gbm-cli/cmd/workspace"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release/integrate"
 )
@@ -24,10 +25,17 @@ var IntegrateCmd = &cobra.Command{
 		version, err := utils.GetVersionArg(args)
 		exitIfError(err, 1)
 
+		gbmPr, err := gbm.FindGbmReleasePr(version)
+		exitIfError(err, 1)
+		if gbmPr.Number == 0 {
+			exitIfError(errors.New("no GBM PR found"), 1)
+		}
+
 		ri := integrate.ReleaseIntegration{
 			Version:    version,
 			BaseBranch: "trunk",
 			HeadBranch: fmt.Sprintf("gutenberg/integrate_release_%s", version),
+			GbmPr:      gbmPr,
 		}
 
 		results := []gh.PullRequest{}

--- a/cli/cmd/release/integrate.go
+++ b/cli/cmd/release/integrate.go
@@ -83,7 +83,9 @@ var IntegrateCmd = &cobra.Command{
 			exitIfError(errors.New("no PRs were created"), 1)
 		}
 		for _, pr := range results {
-			console.Info("Created PR %s", pr.Url)
+			if pr.Number != 0 {
+				console.Info("Created PR %s", pr.Url)
+			}
 		}
 	},
 }

--- a/cli/pkg/gbm/search.go
+++ b/cli/pkg/gbm/search.go
@@ -72,3 +72,7 @@ func FindGbmSyncedPrs(gbmPr gh.PullRequest, filters []gh.RepoFilter) ([]gh.Searc
 
 	return synced, nil
 }
+
+func GetGbmRelease(version string) (gh.Release, error) {
+	return gh.GetReleaseByTag(repo.GutenbergMobileRepo, "v"+version)
+}

--- a/cli/pkg/gbm/search.go
+++ b/cli/pkg/gbm/search.go
@@ -2,7 +2,9 @@ package gbm
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 )
@@ -35,4 +37,38 @@ func FindIosReleasePr(version string) (gh.PullRequest, error) {
 
 	filter := gh.BuildRepoFilter(repo.WordPressIosRepo, "is:open", "is:pr", label, title)
 	return gh.SearchPr(filter)
+}
+func FindGbmSyncedPrs(gbmPr gh.PullRequest, filters []gh.RepoFilter) ([]gh.SearchResult, error) {
+	var synced []gh.SearchResult
+	prChan := make(chan gh.SearchResult)
+
+	// Search for PRs in parallel
+	for _, rf := range filters {
+		go func(rf gh.RepoFilter) {
+			res, err := gh.SearchPrs(rf)
+
+			// just log the error and continue
+			if err != nil {
+				console.Warn("could not search for %s", err)
+			}
+			prChan <- res
+		}(rf)
+	}
+
+	// Wait for all the PRs to be returned
+	for i := 0; i < len(filters); i++ {
+		resp := <-prChan
+		sItems := []gh.PullRequest{}
+
+		for _, pr := range resp.Items {
+			if strings.Contains(pr.Body, gbmPr.Url) {
+				pr.Repo = resp.Filter.Repo
+				sItems = append(sItems, pr)
+			}
+		}
+		resp.Items = sItems
+		synced = append(synced, resp)
+	}
+
+	return synced, nil
 }

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/exec"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
 
@@ -212,7 +213,7 @@ func renderGbmPrBody(version string, pr *gh.PullRequest) error {
 		gh.BuildRepoFilter("WordPress-iOS", "is:open", "is:pr", version+" in:title"),
 	}
 
-	synced, err := gh.FindGbmSyncedPrs(*pr, rfs)
+	synced, err := gbm.FindGbmSyncedPrs(*pr, rfs)
 	if err != nil {
 		console.Error(err)
 	}

--- a/cli/pkg/release/integrate/android.go
+++ b/cli/pkg/release/integrate/android.go
@@ -56,8 +56,12 @@ func (ai AndroidIntegration) GetRepo() string {
 	return repo.WordPressAndroidRepo
 }
 
-func (ai AndroidIntegration) GetPr(version string) (gh.PullRequest, error) {
-	return gbm.FindAndroidReleasePr(version)
+func (ai AndroidIntegration) GetPr(ri ReleaseIntegration) (gh.PullRequest, error) {
+	// @TODO: add support for finding non release PRs
+	if ri.Version != "" {
+		return gbm.FindAndroidReleasePr(ri.Version)
+	}
+	return gh.PullRequest{}, nil
 }
 
 func (ai AndroidIntegration) GbPublished(version string) (bool, error) {

--- a/cli/pkg/release/integrate/integrate.go
+++ b/cli/pkg/release/integrate/integrate.go
@@ -62,6 +62,9 @@ func (ri *ReleaseIntegration) Run(dir string) (gh.PullRequest, error) {
 	if err != nil {
 		return pr, fmt.Errorf("error finding the gbm release PR: %v", err)
 	}
+	if gbmPr.Number == 0 {
+		return pr, errors.New("no GBM PR found")
+	}
 	git := shell.NewGitCmd(shell.CmdProps{Dir: dir, Verbose: true})
 
 	// Clone repo

--- a/cli/pkg/release/integrate/integrate.go
+++ b/cli/pkg/release/integrate/integrate.go
@@ -227,3 +227,18 @@ func renderPrBody(version string, pr *gh.PullRequest, gbmPr gh.PullRequest) erro
 	pr.Body = body
 	return nil
 }
+
+func useRelease(version string) (bool, error) {
+	release, err := gbm.GetGbmRelease(version)
+	if err != nil {
+		console.Warn("Unable to check for a release: %s", err)
+		return false, nil
+	}
+
+	if release.PublishedAt == "" {
+		return false, nil
+	}
+
+	console.Info("Found release v%s – %s", version, release.Url)
+	return true, nil
+}

--- a/cli/pkg/release/integrate/ios.go
+++ b/cli/pkg/release/integrate/ios.go
@@ -72,8 +72,12 @@ func (ii IosIntegration) GetRepo() string {
 	return repo.WordPressIosRepo
 }
 
-func (ia IosIntegration) GetPr(version string) (gh.PullRequest, error) {
-	return gbm.FindIosReleasePr(version)
+func (ia IosIntegration) GetPr(ri ReleaseIntegration) (gh.PullRequest, error) {
+	// @TODO: add support for finding non release PRs
+	if ri.Version != "" {
+		return gbm.FindIosReleasePr(ri.Version)
+	}
+	return gh.PullRequest{}, nil
 }
 
 func (ia IosIntegration) GbPublished(version string) (bool, error) {

--- a/cli/pkg/release/integrate/ios.go
+++ b/cli/pkg/release/integrate/ios.go
@@ -1,6 +1,7 @@
 package integrate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -17,11 +18,23 @@ type IosIntegration struct {
 }
 
 func (ii IosIntegration) UpdateGutenbergConfig(dir string, gbmPr gh.PullRequest) error {
-
 	sp := shell.CmdProps{Dir: dir, Verbose: true}
 	git := shell.NewGitCmd(sp)
-	// TODO update github org although not sure it's useful here
-	console.Info("Update gutenberg-mobile ref in Gutenberg/config.yml")
+
+	// @TODO update github org although not sure it's useful here
+
+	var updates []string
+
+	// Check to see if there is a published release for the version
+	if releaseAvailable, err := useRelease(gbmPr.ReleaseVersion); err != nil {
+		return fmt.Errorf("unable to check for a release: %s", err)
+	} else if releaseAvailable {
+		console.Info("Updating gutenberg-mobile ref to the tag v%s", gbmPr.ReleaseVersion)
+		updates = []string{".ref.tag = \"v" + gbmPr.ReleaseVersion + "\"", "del(.ref.commit)"}
+	} else {
+		console.Info("Updating gutenberg-mobile ref to the commit %s", gbmPr.Head.Sha)
+		updates = []string{".ref.commit = \"v" + gbmPr.Head.Sha + "\"", "del(.ref.tag)"}
+	}
 
 	configPath := filepath.Join(dir, "Gutenberg/config.yml")
 	buf, err := os.ReadFile(configPath)
@@ -29,9 +42,7 @@ func (ii IosIntegration) UpdateGutenbergConfig(dir string, gbmPr gh.PullRequest)
 		return err
 	}
 
-	commit := gbmPr.Head.Sha
 	// perform updates using the yq syntax
-	updates := []string{".ref.commit = \"v" + commit + "\"", "del(.ref.tag)"}
 	config, err := utils.YqEvalAll(updates, string(buf))
 	if err != nil {
 		return err

--- a/cli/pkg/release/integrate/ios.go
+++ b/cli/pkg/release/integrate/ios.go
@@ -29,9 +29,9 @@ func (ii IosIntegration) UpdateGutenbergConfig(dir string, gbmPr gh.PullRequest)
 		return err
 	}
 
-	version := gbmPr.ReleaseVersion
+	commit := gbmPr.Head.Sha
 	// perform updates using the yq syntax
-	updates := []string{".ref.commit = \"v" + version + "\"", "del(.ref.tag)"}
+	updates := []string{".ref.commit = \"v" + commit + "\"", "del(.ref.tag)"}
 	config, err := utils.YqEvalAll(updates, string(buf))
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (ii IosIntegration) UpdateGutenbergConfig(dir string, gbmPr gh.PullRequest)
 		return err
 	}
 
-	return git.CommitAll("Release script: Update gutenberg-mobile ref %s", version)
+	return git.CommitAll("Release script: Update gutenberg-mobile ref %s", gbmPr.ReleaseVersion)
 }
 
 func (ii IosIntegration) GetRepo() string {


### PR DESCRIPTION
Fixes #192 

This updates the integration package to start handling generalized integrations. It can now build integrations for any Gutenberg Mobile PR. It also handles updating release integrations after a new Gutenberg Mobile release is published.

There are a few outstanding TODO's before this package can handle general GBM prs but it's close.
Testing :
- Run the integrate command on GBM fork release PR
- Per the #192 fix, verify that the PRs are updating the config correctly  (if the release has not been published)
- Publish a release on a fork of Gutenberg Mobile using the same version in the previous step
- Run the integration command with the same arguments as before
- Verify that the PRs are updated with the newly published release version 

