### PR TITLE
Cli: Various fixes

### DIFF
--- a/cli/cmd/release/prepare/all.go
+++ b/cli/cmd/release/prepare/all.go
@@ -15,8 +15,10 @@ var allCmd = &cobra.Command{
 	Short: "Prepare Gutenberg and Gutenberg Mobile for a mobile release",
 	Long:  `Use this command to prepare a Gutenberg and Gutenberg Mobile release PRs`,
 	Run: func(cc *cobra.Command, args []string) {
-		preflight(args)
 		var err error
+
+		preflight(args)
+		defer workspace.Cleanup()
 
 		// Set up separate directories for each repo
 		gbDir := filepath.Join(tempDir, "gb")

--- a/cli/cmd/release/prepare/all.go
+++ b/cli/cmd/release/prepare/all.go
@@ -33,7 +33,7 @@ var allCmd = &cobra.Command{
 
 		console.Info("Preparing Gutenberg for release %s", version)
 
-		gbPr, err = release.CreateGbPR(version, gbDir)
+		gbPr, err = release.CreateGbPR(version, gbDir, noTag)
 		exitIfError(err, 1)
 		console.Info("Finished preparing Gutenberg PR")
 

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -16,7 +16,7 @@ var gbCmd = &cobra.Command{
 
 		console.Info("Preparing Gutenberg for release %s", version)
 
-		pr, err := release.CreateGbPR(version, tempDir)
+		pr, err := release.CreateGbPR(version, tempDir, noTag)
 		exitIfError(err, 1)
 
 		console.Info("Created PR %s", pr.Url)

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -12,6 +12,7 @@ var gbCmd = &cobra.Command{
 	Long:  `Use this command to prepare a Gutenberg release PR`,
 	Run: func(cc *cobra.Command, args []string) {
 		preflight(args)
+		defer workspace.Cleanup()
 
 		console.Info("Preparing Gutenberg for release %s", version)
 

--- a/cli/cmd/release/prepare/gbm.go
+++ b/cli/cmd/release/prepare/gbm.go
@@ -12,6 +12,7 @@ var gbmCmd = &cobra.Command{
 	Long:  `Use this command to prepare a Gutenberg Mobile release PR`,
 	Run: func(cmd *cobra.Command, args []string) {
 		preflight(args)
+		defer workspace.Cleanup()
 
 		console.Info("Preparing Gutenberg Mobile for release %s", version)
 

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -23,10 +23,6 @@ var PrepareCmd = &cobra.Command{
 func Execute() {
 	err := PrepareCmd.Execute()
 	exitIfError(err, 1)
-	if keepTempDir {
-		workspace.Keep()
-	}
-	defer workspace.Cleanup()
 }
 
 // Set up the temp directory and version
@@ -40,6 +36,9 @@ func preflight(args []string) {
 	// Validate Aztec version
 	if valid := gbm.ValidateAztecVersions(); !valid {
 		exitIfError(errors.New("invalid Aztec versions found"), 1)
+	}
+	if keepTempDir {
+		workspace.Keep()
 	}
 }
 

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -11,7 +11,7 @@ import (
 )
 
 var exitIfError func(error, int)
-var keepTempDir bool
+var keepTempDir, noTag bool
 var workspace wp.Workspace
 var tempDir, version string
 
@@ -48,7 +48,6 @@ func init() {
 	utils.ExitIfError(err, 1)
 
 	exitIfError = func(err error, code int) {
-
 		if err != nil {
 			console.Error(err)
 			utils.Exit(code, workspace.Cleanup)
@@ -59,4 +58,6 @@ func init() {
 	PrepareCmd.AddCommand(gbCmd)
 	PrepareCmd.AddCommand(allCmd)
 	PrepareCmd.PersistentFlags().BoolVar(&keepTempDir, "k", false, "Keep temporary directory after running command")
+	PrepareCmd.PersistentFlags().BoolVar(&noTag, "no-tag", false, "Prevent tagging the release")
+
 }

--- a/cli/cmd/workspace/workspace.go
+++ b/cli/cmd/workspace/workspace.go
@@ -88,5 +88,10 @@ func (w *workspace) Keep() {
 }
 
 func (w *workspace) Cleanup() {
+	if w.keep {
+		console.Info("Keeping temporary directory %s", w.dir)
+	} else {
+		console.Info("Cleaning up workspace directory %s", w.dir)
+	}
 	w.cleaner()
 }

--- a/cli/pkg/console/console.go
+++ b/cli/pkg/console/console.go
@@ -67,7 +67,7 @@ Use Info to log messages from the scripts. Output is sent to stderr to not muddl
 */
 func Info(format string, args ...interface{}) {
 	cyan := color.New(color.FgCyan).SprintfFunc()
-	l.Printf(cyan("\n"+format, args...))
+	l.Printf(cyan("\n[INFO] "+format, args...))
 	color.Unset()
 }
 
@@ -77,8 +77,8 @@ func Log(format string, args ...interface{}) {
 }
 
 func Debug(format string, args ...interface{}) {
-	blue := color.New(color.FgBlue).SprintfFunc()
-	l.Printf(blue("\n"+format, args...))
+	blue := color.New(color.FgHiBlue).SprintfFunc()
+	l.Printf(blue("\n[DEBUG] "+format, args...))
 	color.Unset()
 }
 
@@ -90,7 +90,7 @@ func Print(c *color.Color, format string, args ...interface{}) {
 
 func Warn(format string, args ...interface{}) {
 	yellow := color.New(color.FgYellow).SprintfFunc()
-	l.Printf(yellow("\n"+format, args...))
+	l.Printf(yellow("\n[WARN] "+format, args...))
 	color.Unset()
 }
 
@@ -100,7 +100,7 @@ func Inspect(i interface{}) {
 
 func Error(err error) {
 	red := color.New(color.FgRed).SprintfFunc()
-	l.Printf(red("\n" + err.Error()))
+	l.Printf(red("\n[ERROR] " + err.Error()))
 	color.Unset()
 }
 

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -142,15 +142,16 @@ func CreateGbPR(version, dir string) (gh.PullRequest, error) {
 		return pr, fmt.Errorf("pr was not created successfully")
 	}
 
-	console.Info("Adding release tag")
-	if err := git.PushTag("rnmobile/" + version); err != nil {
-		console.Warn("Error tagging the release: %v", err)
+	if !noTag {
+		console.Info("Adding release tag")
+		if err := git.PushTag("rnmobile/" + version); err != nil {
+			console.Warn("Error tagging the release: %v", err)
+		}
+	} else {
+		console.Warn("Skipping tag creation")
 	}
-	return pr, nil
-}
 
-func exitIfError(err error, i int) {
-	panic("unimplemented")
+	return pr, nil
 }
 
 func renderGbPrBody(version string, pr *gh.PullRequest) error {

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -53,6 +53,18 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 		}
 	}
 
+	// Update the Gutenberg submodule
+	gbBranch := "rnmobile/release_" + version
+	if org != repo.WpMobileOrg {
+		console.Warn("You are not using the %s org. Check the .gitmodules file to make sure the gutenberg submodule is pointing to %s/gutenberg.", repo.WpMobileOrg, org)
+	}
+	if exists, _ := gh.SearchBranch("gutenberg", gbBranch); (exists == gh.Branch{}) {
+		return pr, fmt.Errorf("the Gutenberg branch %s does not exist on %s/gutenberg-mobile", gbBranch, org)
+	}
+	if err := updateGb(gbBranch, dir, git); err != nil {
+		return pr, fmt.Errorf("error updating the Gutenberg submodule: %v", err)
+	}
+
 	// Set up Gutenberg Mobile node environment
 	console.Info("Setting up Node environment")
 	npm := shell.NewNpmCmd(sp)
@@ -64,39 +76,17 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 		return pr, fmt.Errorf("error running npm ci: %v", err)
 	}
 
-	// Commit package.json and package-lock.json
-	// Update package versions for package.json and package-lock.json
+	// Update package version
 	console.Info("Updating package versions")
-	updatePackageJson(dir, version, "package.json", "package-lock.json")
-
-	// Create a git client for Gutenberg submodule so the Gutenberg ref can be updated to the correct branch
-	console.Info("Updating Gutenberg submodule")
-	gbBranch := "rnmobile/release_" + version
-	if org != repo.WpMobileOrg {
-		console.Warn("You are not using the %s org. Check the .gitmodules file to make sure the gutenberg submodule is pointing to %s/gutenberg.", repo.WpMobileOrg, org)
+	if err := npm.Version(version); err != nil {
+		return pr, fmt.Errorf("error updating the package version: %v", err)
 	}
-	if exists, _ := gh.SearchBranch("gutenberg", gbBranch); (exists == gh.Branch{}) {
-		return pr, fmt.Errorf("the Gutenberg branch %s does not exist on %s/gutenberg-mobile", gbBranch, org)
+	if err := git.CommitAll("Release script: Update package versions to %s", version); err != nil {
+		return pr, fmt.Errorf("error committing the package version update: %v", err)
 	}
 
-	gbSp := sp
-	gbSp.Dir = filepath.Join(dir, "gutenberg")
-	gbGit := shell.NewGitCmd(gbSp)
-
-	if err := gbGit.Fetch(gbBranch); err != nil {
-		return pr, fmt.Errorf("error fetching the Gutenberg branch: %v", err)
-	}
-
-	if err := gbGit.Switch(gbBranch); err != nil {
-		return pr, fmt.Errorf("error checking out the Gutenberg branch: %v", err)
-	}
-
-	if err := git.CommitAll("Release script: Update gutenberg submodule"); err != nil {
-		return pr, fmt.Errorf("error committing the gutenberg submodule update: %v", err)
-	}
-
-	console.Info("Bundling Gutenberg Mobile")
-	if err := npm.Run("bundle"); err != nil {
+	console.Info("Updating i18n files")
+	if err := npm.Run("i18n:update"); err != nil {
 		return pr, fmt.Errorf("error running npm run bundle: %v", err)
 	}
 
@@ -110,27 +100,8 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 		}
 	}
 
-	// Update XCFramework builders project Podfile.lock
-	console.Info("Update XCFramework builders project Podfile.lock")
-
-	// set up a shell command for the ios-xcframework directory
-	xcSp := sp
-	xcSp.Dir = fmt.Sprintf("%s/ios-xcframework", dir)
-	bundle := shell.NewBundlerCmd(xcSp)
-
-	// Run `bundle install`
-	if err := bundle.Install(); err != nil {
-		return pr, fmt.Errorf("error running bundle install: %v", err)
-	}
-
-	// Run `bundle exec pod install``
-	if err := bundle.PodInstall(); err != nil {
-		return pr, fmt.Errorf("error running bundle exec pod install: %v", err)
-	}
-
-	// Commit output of bundle commands
-	if err := git.CommitAll("Release script: Sync XCFramework `Podfile.lock` with %s", version); err != nil {
-		return pr, fmt.Errorf("error committing the XCFramework `Podfile.lock` update: %v", err)
+	if err := updateXcFramework(version, dir, git); err != nil {
+		return pr, fmt.Errorf("error updating the XCFramework builders project: %v", err)
 	}
 
 	// Update the RELEASE-NOTES.txt and commit output
@@ -318,4 +289,51 @@ func getReleaseNotes(dir string, gbmPr *gh.PullRequest) ([]byte, error) {
 	}
 
 	return rn, nil
+}
+
+func updateGb(gbBranch, dir string, git shell.GitCmds) error {
+	console.Info("Updating Gutenberg submodule")
+	// Create a git client for Gutenberg submodule so the Gutenberg ref can be
+	// updated to the correct branch
+	gbSp := shell.CmdProps{Dir: filepath.Join(dir, "gutenberg"), Verbose: true}
+	gbGit := shell.NewGitCmd(gbSp)
+
+	if err := gbGit.Fetch(gbBranch); err != nil {
+		return fmt.Errorf("error fetching the Gutenberg branch: %v", err)
+	}
+
+	if err := gbGit.Switch(gbBranch); err != nil {
+		return fmt.Errorf("error checking out the Gutenberg branch: %v", err)
+	}
+
+	if err := git.CommitAll("Release script: Update gutenberg submodule"); err != nil {
+		return fmt.Errorf("error committing the gutenberg submodule update: %v", err)
+	}
+	return nil
+}
+
+func updateXcFramework(version, dir string, git shell.GitCmds) error {
+	console.Info("Update XCFramework builders project Podfile.lock")
+
+	// set up a shell command for the ios-xcframework directory
+	xcSp := shell.CmdProps{Dir: fmt.Sprintf("%s/ios-xcframework", dir), Verbose: true}
+
+	bundle := shell.NewBundlerCmd(xcSp)
+
+	// Run `bundle install`
+	if err := bundle.Install(); err != nil {
+		return fmt.Errorf("error running bundle install: %v", err)
+	}
+
+	// Run `bundle exec pod install``
+	if err := bundle.PodInstall(); err != nil {
+		return fmt.Errorf("error running bundle exec pod install: %v", err)
+	}
+
+	// Commit output of bundle commands
+	if err := git.CommitAll("Release script: Sync XCFramework `Podfile.lock` with %s", version); err != nil {
+		return fmt.Errorf("error committing the XCFramework `Podfile.lock` update: %v", err)
+	}
+
+	return nil
 }

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -61,7 +61,7 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 	if exists, _ := gh.SearchBranch("gutenberg", gbBranch); (exists == gh.Branch{}) {
 		return pr, fmt.Errorf("the Gutenberg branch %s does not exist on %s/gutenberg-mobile", gbBranch, org)
 	}
-	if err := updateGb(gbBranch, dir, git); err != nil {
+	if err := updateGbSubmodule(gbBranch, dir, git); err != nil {
 		return pr, fmt.Errorf("error updating the Gutenberg submodule: %v", err)
 	}
 
@@ -291,7 +291,7 @@ func getReleaseNotes(dir string, gbmPr *gh.PullRequest) ([]byte, error) {
 	return rn, nil
 }
 
-func updateGb(gbBranch, dir string, git shell.GitCmds) error {
+func updateGbSubmodule(gbBranch, dir string, git shell.GitCmds) error {
 	console.Info("Updating Gutenberg submodule")
 	// Create a git client for Gutenberg submodule so the Gutenberg ref can be
 	// updated to the correct branch

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -1,32 +1,13 @@
 package release
 
 import (
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
-	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 )
-
-func updatePackageJson(dir, version string, pkgs ...string) error {
-	sp := shell.CmdProps{Dir: dir, Verbose: true}
-	git := shell.NewGitCmd(sp)
-
-	for _, pkg := range pkgs {
-		if err := utils.UpdatePackageVersion(version, filepath.Join(dir, pkg)); err != nil {
-			return err
-		}
-	}
-	if err := git.CommitAll("Release script: Update package.json versions to %s", version); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 type ReleaseChanges struct {
 	Title  string

--- a/cli/pkg/shell/cmds.go
+++ b/cli/pkg/shell/cmds.go
@@ -11,21 +11,28 @@ type CmdProps struct {
 }
 
 type client struct {
-	cmd func(...string) error
+	cmd       func(...string) error
+	cmdInPath func(string, ...string) error
+}
+
+func execute(cmd *exec.Cmd, dir string, verbose bool) error {
+	cmd.Dir = dir
+	if verbose {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+	return cmd.Run()
 }
 
 func NewNpmCmd(cp CmdProps) NpmCmds {
 	return &client{
 		cmd: func(cmds ...string) error {
 			cmd := exec.Command("npm", cmds...)
-			cmd.Dir = cp.Dir
-
-			if cp.Verbose {
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-			}
-
-			return cmd.Run()
+			return execute(cmd, cp.Dir, cp.Verbose)
+		},
+		cmdInPath: func(path string, cmds ...string) error {
+			cmd := exec.Command("npm", cmds...)
+			return execute(cmd, path, cp.Verbose)
 		},
 	}
 }
@@ -34,14 +41,11 @@ func NewGitCmd(cp CmdProps) GitCmds {
 	return &client{
 		cmd: func(cmds ...string) error {
 			cmd := exec.Command("git", cmds...)
-			cmd.Dir = cp.Dir
-
-			if cp.Verbose {
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-			}
-
-			return cmd.Run()
+			return execute(cmd, cp.Dir, cp.Verbose)
+		},
+		cmdInPath: func(path string, cmds ...string) error {
+			cmd := exec.Command("git", cmds...)
+			return execute(cmd, path, cp.Verbose)
 		},
 	}
 }
@@ -50,14 +54,11 @@ func NewBundlerCmd(cp CmdProps) BundlerCmds {
 	return &client{
 		cmd: func(cmds ...string) error {
 			cmd := exec.Command("bundle", cmds...)
-			cmd.Dir = cp.Dir
-
-			if cp.Verbose {
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-			}
-
-			return cmd.Run()
+			return execute(cmd, cp.Dir, cp.Verbose)
+		},
+		cmdInPath: func(path string, cmds ...string) error {
+			cmd := exec.Command("bundle", cmds...)
+			return execute(cmd, path, cp.Verbose)
 		},
 	}
 }
@@ -66,14 +67,11 @@ func NewRakeCmd(cp CmdProps) RakeCmds {
 	return &client{
 		cmd: func(cmds ...string) error {
 			cmd := exec.Command("rake", cmds...)
-			cmd.Dir = cp.Dir
-
-			if cp.Verbose {
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-			}
-
-			return cmd.Run()
+			return execute(cmd, cp.Dir, cp.Verbose)
+		},
+		cmdInPath: func(path string, cmds ...string) error {
+			cmd := exec.Command("rake", cmds...)
+			return execute(cmd, path, cp.Verbose)
 		},
 	}
 }

--- a/cli/pkg/shell/npm.go
+++ b/cli/pkg/shell/npm.go
@@ -1,9 +1,14 @@
 package shell
 
+import "github.com/wordpress-mobile/gbm-cli/pkg/console"
+
 type NpmCmds interface {
 	Install(...string) error
 	Ci() error
 	Run(...string) error
+	RunIn(string, ...string) error
+	Version(string) error
+	VersionIn(string, string) error
 }
 
 func (c *client) Ci() error {
@@ -13,4 +18,22 @@ func (c *client) Ci() error {
 func (c *client) Run(args ...string) error {
 	run := append([]string{"run"}, args...)
 	return c.cmd(run...)
+}
+
+func (c *client) RunIn(path string, args ...string) error {
+	run := append([]string{"run"}, args...)
+	return c.cmdInPath(path, run...)
+}
+
+func (c *client) Version(version string) error {
+	// Let's not add the tag by default.
+	// If we need it we should consider a different function.
+	versionCmd := []string{"version", version, "--no-git-tag=false"}
+	return c.cmd(versionCmd...)
+}
+
+func (c *client) VersionIn(packagePath, version string) error {
+	console.Debug("Running npm version %s in %s", version, packagePath)
+	versionCmd := []string{"version", version, "--no-git-tag=false"}
+	return c.cmdInPath(packagePath, versionCmd...)
 }

--- a/cli/pkg/utils/utils.go
+++ b/cli/pkg/utils/utils.go
@@ -1,10 +1,7 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
-	"io"
-	"os"
 	"regexp"
 	"time"
 )
@@ -39,43 +36,4 @@ func NormalizeVersion(version string) (string, error) {
 		return "", fmt.Errorf("invalid version")
 	}
 	return v, nil
-}
-
-func UpdatePackageVersion(version, path string) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	packJson, err := io.ReadAll(f)
-	if err != nil {
-		return err
-	}
-
-	update, err := updatePackageJsonVersion(version, packJson)
-	if err != nil {
-		return err
-	}
-
-	w, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer w.Close()
-	if _, err := w.Write(update); err != nil {
-		return err
-	}
-	return nil
-}
-
-func updatePackageJsonVersion(version string, packJson []byte) ([]byte, error) {
-
-	re := regexp.MustCompile(`("version"\s*:\s*)"(?:.*)"`)
-
-	if match := re.Match(packJson); !match {
-		return nil, errors.New("cannot find a version in the json file")
-	}
-	repl := fmt.Sprintf(`$1"%s"`, version)
-	return re.ReplaceAll(packJson, []byte(repl)), nil
 }


### PR DESCRIPTION
This fixes and cleans up a few issues:
1. Switch to using `npm version` to update package.json files 
2. Re-order when the GBM release prepare steps update Gutenberg
3. Fix issues on how the command workspaces are manages 
4. Add log level to the console output (plus us a higher contrast color for debugging)
5. Allow for skip adding the tag on GB


Testing:
- 'release prepare all {version}` should succeed (* Note this intermittent issue #195 ) 
- Verify that the modified `package.json` and `package-lock.json` files are correct i.e. The only changes should to the package version and nothing else
