### PR TITLE
CLI: Use npm install when setting up Gutenberg

### DIFF
--- a/cli/cmd/release/root.go
+++ b/cli/cmd/release/root.go
@@ -32,5 +32,5 @@ func init() {
 	ReleaseCmd.AddCommand(prepare.PrepareCmd)
 	ReleaseCmd.AddCommand(IntegrateCmd)
 	ReleaseCmd.AddCommand(StatusCmd)
-	ReleaseCmd.PersistentFlags().BoolVar(&keepTempDir, "k", false, "Keep temporary directory after running command")
+	ReleaseCmd.PersistentFlags().BoolVar(&keepTempDir, "keep", false, "Keep temporary directory after running command")
 }

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -58,11 +58,6 @@ func CreateGbPR(version, dir string, noTag bool) (gh.PullRequest, error) {
 		if err := npm.VersionIn(editorPackPath, version); err != nil {
 			return pr, fmt.Errorf("error updating the package version: %v", err)
 		}
-		/*
-			if err := utils.UpdatePackageVersion(version, editorPackPath); err != nil {
-				return pr, fmt.Errorf("error updating the package version: %v", err)
-			}
-		*/
 	}
 
 	if err := git.CommitAll("Release script: Update react-native-editor version to %s", version); err != nil {
@@ -84,7 +79,7 @@ func CreateGbPR(version, dir string, noTag bool) (gh.PullRequest, error) {
 		return pr, fmt.Errorf("error setting up the node environment: %v", err)
 	}
 
-	if err := npm.Ci(); err != nil {
+	if err := npm.Install(); err != nil {
 		return pr, fmt.Errorf("error running npm ci: %v", err)
 	}
 

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/exec"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/render"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
@@ -75,7 +74,7 @@ func CreateGbPR(version, dir string, noTag bool) (gh.PullRequest, error) {
 
 	console.Info("Setting up Gutenberg node environment")
 
-	if err := exec.SetupNode(dir, true); err != nil {
+	if err := utils.SetupNode(dir); err != nil {
 		return pr, fmt.Errorf("error setting up the node environment: %v", err)
 	}
 

--- a/cli/pkg/utils/utils.go
+++ b/cli/pkg/utils/utils.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"time"
+)
+
+func ValidateVersion(version string) bool {
+	re := regexp.MustCompile(`v*(\d+)\.(\d+)\.(\d+)$`)
+	return re.MatchString(version)
+}
+
+func IsScheduledRelease(version string) bool {
+	re := regexp.MustCompile(`^v*(\d+)\.(\d+)\.0$`)
+	return re.MatchString(version)
+}
+
+func NextReleaseDate() string {
+	weekday := time.Now().Weekday()
+	daysUntilThursday := 4 - weekday
+
+	nextThursday := time.Now().AddDate(0, 0, int(daysUntilThursday))
+
+	return nextThursday.Format("Monday January 2, 2006")
+}
+
+func NormalizeVersion(version string) (string, error) {
+	v := version
+	if version[0] == 'v' {
+		v = version[1:]
+	}
+
+	re := regexp.MustCompile(`\d+\.\d+\.\d+`)
+	if !re.MatchString(v) {
+		return "", fmt.Errorf("invalid version")
+	}
+	return v, nil
+}
+
+func SetupNode(dir string) error {
+	var cmd *exec.Cmd
+
+	// Check for nvm
+	if os.Getenv("NVM_DIR") != "" {
+		cmd = exec.Command("bash", "-l", "-c", "$NVM_DIR/nvm.sh", "use")
+		cmd.Path = "/bin/bash"
+	}
+
+	// @TODO check for asdf and set up the command accordingly
+
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+
+}


### PR DESCRIPTION
Gutenberg has a package-lock linter to make sure the local package versions match what's in the package lock.
Running `npm ci` won't update the lock file but `npm i` will

This changes the npm command to use `install`

Testing:
- Try preparing Gutenberg for a release
- Verify that the root package-lock.json file is updated.