### PR TITLE
Cli/console cleanup

### DIFF
--- a/cli/pkg/console/console.go
+++ b/cli/pkg/console/console.go
@@ -67,7 +67,7 @@ Use Info to log messages from the scripts. Output is sent to stderr to not muddl
 */
 func Info(format string, args ...interface{}) {
 	cyan := color.New(color.FgCyan).SprintfFunc()
-	l.Printf(cyan("\n[INFO] "+format, args...))
+	l.Printf(cyan("[INFO] "+format, args...))
 	color.Unset()
 }
 
@@ -78,7 +78,7 @@ func Log(format string, args ...interface{}) {
 
 func Debug(format string, args ...interface{}) {
 	blue := color.New(color.FgHiBlue).SprintfFunc()
-	l.Printf(blue("\n[DEBUG] "+format, args...))
+	l.Printf(blue("[DEBUG] "+format, args...))
 	color.Unset()
 }
 
@@ -90,7 +90,7 @@ func Print(c *color.Color, format string, args ...interface{}) {
 
 func Warn(format string, args ...interface{}) {
 	yellow := color.New(color.FgYellow).SprintfFunc()
-	l.Printf(yellow("\n[WARN] "+format, args...))
+	l.Printf(yellow("[WARN] "+format, args...))
 	color.Unset()
 }
 
@@ -100,7 +100,7 @@ func Inspect(i interface{}) {
 
 func Error(err error) {
 	red := color.New(color.FgRed).SprintfFunc()
-	l.Printf(red("\n[ERROR] " + err.Error()))
+	l.Printf(red("[ERROR] " + err.Error() + "\n"))
 	color.Unset()
 }
 

--- a/cli/pkg/gh/gh.go
+++ b/cli/pkg/gh/gh.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/fatih/color"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/exec"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
+	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
 )
 
 // Branch represents a GitHub branch API schema.
@@ -358,17 +358,18 @@ func labelRequest(rpo string, prNum int, labels []string) ([]Label, error) {
 
 func PreviewPr(rpo, dir string, pr PullRequest) {
 	org := repo.GetOrg(rpo)
-	cyan := color.New(color.FgCyan, color.Bold).SprintfFunc()
-	console.Log(cyan("\nPr Preview"))
-	console.Log(cyan("Local:")+" %s\n", dir)
-	console.Log(cyan("Repo:")+" %s/%s\n", org, rpo)
-	console.Log(cyan("Title:")+" %s\n", pr.Title)
-	console.Log(cyan("Body:\n")+"%s\n", pr.Body)
-	console.Log(cyan("Commits:"))
+	row := console.Row
 
-	git := exec.Git(dir, true)
+	console.Print(console.Heading, "\nPr Preview")
 
-	git("log", pr.Base.Ref+"...HEAD", "--oneline", "--no-merges", "-10")
+	white := color.New(color.FgWhite).SprintFunc()
 
-	console.Info("\n")
+	console.Print(row, "Repo: %s/%s", white(org), white(rpo))
+	console.Print(row, "Title: %s", white(pr.Title))
+	console.Print(row, "Body:\n%s", white(pr.Body))
+	console.Print(row, "Commits:")
+
+	git := shell.NewGitCmd(shell.CmdProps{Dir: dir, Verbose: true})
+
+	git.Log(pr.Base.Ref+"...HEAD", "--oneline", "--no-merges", "-10")
 }

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -108,7 +108,7 @@ func CreateGbPR(version, dir string, noTag bool) (gh.PullRequest, error) {
 		return pr, fmt.Errorf("error committing the Podfile changes: %v", err)
 	}
 
-	console.Info("\n 🎉 Gutenberg preparations succeeded.")
+	console.Info("🎉 Gutenberg preparations succeeded.")
 
 	// Prepare the GB PR
 	console.Info("Creating PR")

--- a/cli/pkg/shell/git.go
+++ b/cli/pkg/shell/git.go
@@ -19,6 +19,7 @@ type GitCmds interface {
 	SetUpstreamTo(...string) error
 	IsPorcelain() bool
 	PushTag(string, ...string) error
+	Log(...string) error
 }
 
 func (c *client) Clone(args ...string) error {
@@ -94,4 +95,9 @@ func (c *client) PushTag(tag string, annotate ...string) error {
 		return err
 	}
 	return c.cmd("push", "origin", tag)
+}
+
+func (c *client) Log(args ...string) error {
+	log := append([]string{"log"}, args...)
+	return c.cmd(log...)
 }


### PR DESCRIPTION
Console cleanup
- Remove most of the newlines in the general log messages
- Clean up the PR preview so it's more readable