### PR TITLE
CLI: Reorganize release domain code

### DIFF
--- a/cli/cmd/release/integrate.go
+++ b/cli/cmd/release/integrate.go
@@ -10,8 +10,8 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	wp "github.com/wordpress-mobile/gbm-cli/cmd/workspace"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release/integrate"
 )
 
@@ -25,7 +25,7 @@ var IntegrateCmd = &cobra.Command{
 		version, err := utils.GetVersionArg(args)
 		exitIfError(err, 1)
 
-		gbmPr, err := gbm.FindGbmReleasePr(version)
+		gbmPr, err := release.FindGbmReleasePr(version)
 		exitIfError(err, 1)
 		if gbmPr.Number == 0 {
 			exitIfError(errors.New("no GBM PR found"), 1)

--- a/cli/cmd/release/status.go
+++ b/cli/cmd/release/status.go
@@ -1,11 +1,13 @@
 package release
 
 import (
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/cmd/utils"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 )
 
@@ -21,33 +23,52 @@ var StatusCmd = &cobra.Command{
 		heading := console.Heading
 		headingRow := console.HeadingRow
 		row := console.Row
+		basic := color.New(color.FgWhite)
 
 		console.Print(heading, "\nRelease %s Status\n", version)
+
+		// Check to see if the release has been published
+		rel, err := release.GetGbmRelease(version)
+		exitIfError(err, 1)
+
+		if (rel != gh.Release{}) {
+			console.Print(heading, "\n🎉 Release %s has been published!\n %s\n", version, rel.Url)
+		}
 
 		prs := []gh.PullRequest{}
 		gbPr, gbmPr, androidPr, iosPr := gh.PullRequest{}, gh.PullRequest{}, gh.PullRequest{}, gh.PullRequest{}
 
 		// @TODO: search for gb pr
+		gbPr, err = release.FindGbReleasePr(version)
+		if err != nil {
+			console.Warn("Could not get Gutenberg PR: %s", err)
+		}
 		gbPr.Repo = repo.GetOrg("gutenberg") + "/gutenberg"
 		prs = append(prs, gbPr)
 
-		gbmPr, err = gbm.FindGbmReleasePr(version)
-		exitIfError(err, 1)
+		gbmPr, err = release.FindGbmReleasePr(version)
+		if err != nil {
+			console.Warn("Could not get Gutenberg Mobile PR: %s", err)
+		}
 		gbmPr.Repo = repo.GetOrg("gutenberg-mobile") + "/gutenberg-mobile"
 		prs = append(prs, gbmPr)
 
-		androidPr, err = gbm.FindAndroidReleasePr(version)
-		exitIfError(err, 1)
+		androidPr, err = release.FindAndroidReleasePr(version)
+		if err != nil {
+			console.Warn("Could not find Android PR: %s", err)
+		}
 		androidPr.Repo = repo.GetOrg("WordPress-Android") + "/WordPress-Android"
 		prs = append(prs, androidPr)
 
-		iosPr, err = gbm.FindIosReleasePr(version)
-		exitIfError(err, 1)
+		iosPr, err = release.FindIosReleasePr(version)
+		if err != nil {
+			console.Warn("Could not find iOS PR: %s", err)
+		}
 		iosPr.Repo = repo.GetOrg("WordPress-iOS") + "/WordPress-iOS"
 		prs = append(prs, iosPr)
 
 		console.Print(heading, "Release Prs:")
-		console.Print(headingRow, "%-27s %-10s %-10v %s", "Repo", "State", "Mergeable", "Url")
+		console.Print(headingRow, "%-36s %-10s %-10v %s", "Repo", "State", "Mergeable", "Url")
 
 		// List the PRs
 		for _, pr := range prs {
@@ -55,28 +76,32 @@ var StatusCmd = &cobra.Command{
 				pr.State = "…"
 				pr.Url = "…"
 			}
-			console.Print(row, "• %-25s %-10s %-10v %s", pr.Repo, pr.State, pr.Mergeable, pr.Url)
+			console.Print(row, "• %-34s %-10s %-10v %s", pr.Repo, pr.State, pr.Mergeable, pr.Url)
 		}
 
 		// Get the status for the head sha
-
-		console.Print(heading, "\nGutenberg Mobile Build Status")
+		console.Print(heading, "\nGutenberg Mobile Build Status\n")
 		if gbmPr.Number == 0 {
-			console.Info("...Waiting for Gutenberg Mobile PR to be created before checking build status")
+			console.Print(row, "...Waiting for Gutenberg Mobile PR to be created before checking build status")
 			return
 		}
 		sha := gbmPr.Head.Sha
-		console.Info("Getting Gutenberg Builds for sha: %s", sha)
-		exitIfError(err, 1)
+		console.Print(basic, "Getting Gutenberg Builds for sha: %s", sha)
 
-		androidReady, err := gbm.AndroidGbmBuildPublished(version)
-		exitIfError(err, 1)
+		console.Print(headingRow, "%-10s %-10s", "Platform", "Status")
 
-		iosReady, err := gbm.IosGbmBuildPublished(version)
-		exitIfError(err, 1)
+		androidReady, err := gbm.AndroidGbmBuildPublished(gbmPr)
+		if err != nil {
+			console.Warn("Could not get Android build status: %s", err)
+		}
 
-		console.Info("Android Build Ready: %v", androidReady)
-		console.Info("iOS Build Ready: %v", iosReady)
+		iosReady, err := gbm.IosGbmBuildPublished(gbmPr)
+
+		if err != nil {
+			console.Warn("Could not get iOS build status: %s", err)
+		}
+		console.Print(row, "%-10s %-10v", "Android", androidReady)
+		console.Print(row, "%-10s %-10v", "iOS", iosReady)
 
 	},
 }

--- a/cli/pkg/gbm/builds.go
+++ b/cli/pkg/gbm/builds.go
@@ -1,18 +1,12 @@
 package gbm
 
 import (
-	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 )
 
-func AndroidGbmBuildPublished(version string) (bool, error) {
+func AndroidGbmBuildPublished(pr gh.PullRequest) (bool, error) {
 	// Forcing the search to look in the wordpress-mobile org
 	// Since forks will not have the status checks
-	pr, err := FindGbmReleasePr(version)
-	console.Info("Checking status for %s %s", pr.Title, pr.Url)
-	if err != nil {
-		return false, err
-	}
 	sha := pr.Head.Sha
 	status, err := gh.GetStatusCheck("gutenberg-mobile", sha, "build-android-rn-bridge-and-publish-to-s3")
 	if err != nil {
@@ -21,14 +15,9 @@ func AndroidGbmBuildPublished(version string) (bool, error) {
 	return status.State == "success", nil
 }
 
-func IosGbmBuildPublished(version string) (bool, error) {
+func IosGbmBuildPublished(pr gh.PullRequest) (bool, error) {
 	// Forcing the search to look in the wordpress-mobile org
 	// Since forks will not have the status checks
-	pr, err := FindGbmReleasePr(version)
-	console.Info("Checking status for %s %s", pr.Title, pr.Url)
-	if err != nil {
-		return false, err
-	}
 	sha := pr.Head.Sha
 	status, err := gh.GetStatusCheck("gutenberg-mobile", sha, "build-ios-rn-xcframework-and-publish-to-s3")
 	if err != nil {

--- a/cli/pkg/gbm/constants.go
+++ b/cli/pkg/gbm/constants.go
@@ -1,4 +1,0 @@
-package gbm
-
-const GbmReleasePrLabel = "release-process"
-const IntegrationPrLabel = "Gutenberg"

--- a/cli/pkg/gbm/search.go
+++ b/cli/pkg/gbm/search.go
@@ -1,43 +1,12 @@
 package gbm
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
-	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 )
 
-func FindGbmReleasePr(version string) (gh.PullRequest, error) {
-	label := fmt.Sprintf("label:%s", GbmReleasePrLabel)
-	title := fmt.Sprintf("%s in:title", version)
-
-	filter := gh.BuildRepoFilter(repo.GutenbergMobileRepo, "is:pr", "is:open", label, title)
-	pr, err := gh.SearchPr(filter)
-	if err != nil {
-		return gh.PullRequest{}, err
-	}
-	pr.ReleaseVersion = version
-	return pr, nil
-}
-
-func FindAndroidReleasePr(version string) (gh.PullRequest, error) {
-	label := fmt.Sprintf("label:%s", IntegrationPrLabel)
-	title := fmt.Sprintf("v%s in:title", version)
-
-	filter := gh.BuildRepoFilter(repo.WordPressAndroidRepo, "is:open", "is:pr", label, title)
-
-	return gh.SearchPr(filter)
-}
-
-func FindIosReleasePr(version string) (gh.PullRequest, error) {
-	label := fmt.Sprintf("label:%s", IntegrationPrLabel)
-	title := fmt.Sprintf("v%s in:title", version)
-
-	filter := gh.BuildRepoFilter(repo.WordPressIosRepo, "is:open", "is:pr", label, title)
-	return gh.SearchPr(filter)
-}
 func FindGbmSyncedPrs(gbmPr gh.PullRequest, filters []gh.RepoFilter) ([]gh.SearchResult, error) {
 	var synced []gh.SearchResult
 	prChan := make(chan gh.SearchResult)
@@ -71,8 +40,4 @@ func FindGbmSyncedPrs(gbmPr gh.PullRequest, filters []gh.RepoFilter) ([]gh.Searc
 	}
 
 	return synced, nil
-}
-
-func GetGbmRelease(version string) (gh.Release, error) {
-	return gh.GetReleaseByTag(repo.GutenbergMobileRepo, "v"+version)
 }

--- a/cli/pkg/gh/gh.go
+++ b/cli/pkg/gh/gh.go
@@ -165,10 +165,6 @@ func SearchPr(filter RepoFilter) (PullRequest, error) {
 		return PullRequest{}, nil
 	}
 	if result.TotalCount > 1 {
-		console.Warn("Found too many PRs for %s", filter.QueryString)
-		for _, pr := range result.Items {
-			console.Info("%s %s", pr.Title, pr.Url)
-		}
 		return PullRequest{}, fmt.Errorf("too many PRs found")
 	}
 	number := result.Items[0].Number

--- a/cli/pkg/release/constants.go
+++ b/cli/pkg/release/constants.go
@@ -1,0 +1,10 @@
+package release
+
+const GbReleasePrLabel = "Mobile App - i.e. Android or iOS"
+
+const GbmReleasePrLabel = "release-process"
+
+const IntegrateBranchName = "gutenberg/integrate_release_%s"
+const IntegrateAfterBranchName = "gutenberg/after_%s"
+const IntegratePrTitle = "Integrate gutenberg-mobile release v%s"
+const IntegratePrLabel = "Gutenberg"

--- a/cli/pkg/release/integrate/android.go
+++ b/cli/pkg/release/integrate/android.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
+
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
@@ -59,7 +61,7 @@ func (ai AndroidIntegration) GetRepo() string {
 func (ai AndroidIntegration) GetPr(ri ReleaseIntegration) (gh.PullRequest, error) {
 	// @TODO: add support for finding non release PRs
 	if ri.Version != "" {
-		return gbm.FindAndroidReleasePr(ri.Version)
+		return release.FindAndroidReleasePr(ri.Version)
 	}
 	return gh.PullRequest{}, nil
 }

--- a/cli/pkg/release/integrate/android.go
+++ b/cli/pkg/release/integrate/android.go
@@ -66,8 +66,8 @@ func (ai AndroidIntegration) GetPr(ri ReleaseIntegration) (gh.PullRequest, error
 	return gh.PullRequest{}, nil
 }
 
-func (ai AndroidIntegration) GbPublished(version string) (bool, error) {
-	published, err := gbm.AndroidGbmBuildPublished(version)
+func (ai AndroidIntegration) GbPublished(gbmPr gh.PullRequest) (bool, error) {
+	published, err := gbm.AndroidGbmBuildPublished(gbmPr)
 	if err != nil {
 		console.Warn("Error checking if GBM build is published: %v", err)
 	}

--- a/cli/pkg/release/integrate/integrate.go
+++ b/cli/pkg/release/integrate/integrate.go
@@ -33,7 +33,7 @@ type Target interface {
 	UpdateGutenbergConfig(dir string, gbmPr gh.PullRequest) error
 	GetRepo() string
 	GetPr(ri ReleaseIntegration) (gh.PullRequest, error)
-	GbPublished(version string) (bool, error)
+	GbPublished(gh.PullRequest) (bool, error)
 }
 
 func (ri *ReleaseIntegration) Run(dir string) (gh.PullRequest, error) {
@@ -43,7 +43,7 @@ func (ri *ReleaseIntegration) Run(dir string) (gh.PullRequest, error) {
 	// Check if the GBM build is published
 	// Only if the target is wordpress-mobile
 	if org == "wordpress-mobile" {
-		published, err := ri.Target.GbPublished(ri.Version)
+		published, err := ri.Target.GbPublished(ri.GbmPr)
 		if err != nil {
 			return gh.PullRequest{}, err
 		}

--- a/cli/pkg/release/integrate/integrate.go
+++ b/cli/pkg/release/integrate/integrate.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
-	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 	"github.com/wordpress-mobile/gbm-cli/pkg/render"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
@@ -113,7 +113,7 @@ func (ri *ReleaseIntegration) cloneRepo(git shell.GitCmds) error {
 	rpo := ri.Target.GetRepo()
 	repoPath := repo.GetRepoPath(rpo)
 
-	branch := "gutenberg/integrate_release_" + ri.Version
+	branch := fmt.Sprintf(release.IntegrateBranchName, ri.Version)
 	exists, err := gh.SearchBranch(rpo, branch)
 	if err != nil {
 		return err
@@ -147,7 +147,7 @@ func (ri *ReleaseIntegration) cloneRepo(git shell.GitCmds) error {
 
 func (ri *ReleaseIntegration) createAfterBranch(git shell.GitCmds) error {
 	rpo := ri.Target.GetRepo()
-	afterBranch := "gutenberg/after_" + ri.Version
+	afterBranch := fmt.Sprintf(release.IntegrateAfterBranchName, ri.Version)
 	// Check if branch exits
 	exists, err := gh.SearchBranch(rpo, afterBranch)
 	if err != nil {
@@ -182,7 +182,7 @@ func (ri *ReleaseIntegration) createPR(dir string, gbmPr gh.PullRequest) (gh.Pul
 	version := ri.Version
 	pr := gh.PullRequest{}
 	console.Info("Creating PR")
-	pr.Title = fmt.Sprint("Integrate gutenberg-mobile release v", ri.Version)
+	pr.Title = fmt.Sprintf(release.IntegratePrTitle, ri.Version)
 	pr.Base.Ref = ri.BaseBranch
 	pr.Head.Ref = ri.HeadBranch
 
@@ -191,7 +191,7 @@ func (ri *ReleaseIntegration) createPR(dir string, gbmPr gh.PullRequest) (gh.Pul
 	}
 
 	pr.Labels = []gh.Label{{
-		Name: gbm.IntegrationPrLabel,
+		Name: release.IntegratePrLabel,
 	}}
 
 	rpo := ri.Target.GetRepo()
@@ -224,7 +224,7 @@ func renderPrBody(version string, pr *gh.PullRequest, gbmPr gh.PullRequest) erro
 }
 
 func useRelease(version string) (bool, error) {
-	release, err := gbm.GetGbmRelease(version)
+	release, err := release.GetGbmRelease(version)
 	if err != nil {
 		console.Warn("Unable to check for a release: %s", err)
 		return false, nil

--- a/cli/pkg/release/integrate/ios.go
+++ b/cli/pkg/release/integrate/ios.go
@@ -8,6 +8,7 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
 	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
@@ -75,7 +76,7 @@ func (ii IosIntegration) GetRepo() string {
 func (ia IosIntegration) GetPr(ri ReleaseIntegration) (gh.PullRequest, error) {
 	// @TODO: add support for finding non release PRs
 	if ri.Version != "" {
-		return gbm.FindIosReleasePr(ri.Version)
+		return release.FindIosReleasePr(ri.Version)
 	}
 	return gh.PullRequest{}, nil
 }

--- a/cli/pkg/release/integrate/ios.go
+++ b/cli/pkg/release/integrate/ios.go
@@ -81,8 +81,8 @@ func (ia IosIntegration) GetPr(ri ReleaseIntegration) (gh.PullRequest, error) {
 	return gh.PullRequest{}, nil
 }
 
-func (ia IosIntegration) GbPublished(version string) (bool, error) {
-	published, err := gbm.IosGbmBuildPublished(version)
+func (ia IosIntegration) GbPublished(gbmPr gh.PullRequest) (bool, error) {
+	published, err := gbm.IosGbmBuildPublished(gbmPr)
 	if err != nil {
 		console.Warn("Error checking if GBM build is published: %v", err)
 	}

--- a/cli/pkg/release/search.go
+++ b/cli/pkg/release/search.go
@@ -1,0 +1,57 @@
+package release
+
+import (
+	"fmt"
+
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
+)
+
+func FindGbReleasePr(version string) (gh.PullRequest, error) {
+	label := fmt.Sprintf("label:\"%s\"", GbReleasePrLabel)
+	title := fmt.Sprintf("v%s in:title", version)
+	filter := gh.BuildRepoFilter(repo.GutenbergRepo, "is:pr", label, title)
+
+	pr, err := gh.SearchPr(filter)
+	if err != nil {
+		return gh.PullRequest{}, err
+	}
+	pr.ReleaseVersion = version
+	return pr, nil
+}
+
+func FindGbmReleasePr(version string) (gh.PullRequest, error) {
+	label := fmt.Sprintf("label:%s", GbmReleasePrLabel)
+	title := fmt.Sprintf("%s in:title", version)
+
+	filter := gh.BuildRepoFilter(repo.GutenbergMobileRepo, "is:pr", label, title)
+	pr, err := gh.SearchPr(filter)
+	if err != nil {
+		return gh.PullRequest{}, err
+	}
+	pr.ReleaseVersion = version
+	return pr, nil
+}
+
+func FindAndroidReleasePr(version string) (gh.PullRequest, error) {
+	label := fmt.Sprintf("label:%s", IntegratePrLabel)
+	title := fmt.Sprintf(IntegratePrTitle+" in:title", version)
+
+	filter := gh.BuildRepoFilter(repo.WordPressAndroidRepo, "is:pr", label, title)
+	console.Debug(filter.QueryString)
+
+	return gh.SearchPr(filter)
+}
+
+func FindIosReleasePr(version string) (gh.PullRequest, error) {
+	label := fmt.Sprintf("label:%s", IntegratePrLabel)
+	title := fmt.Sprintf(IntegratePrTitle+" in:title", version)
+
+	filter := gh.BuildRepoFilter(repo.WordPressIosRepo, "is:pr", label, title)
+	return gh.SearchPr(filter)
+}
+
+func GetGbmRelease(version string) (gh.Release, error) {
+	return gh.GetReleaseByTag(repo.GutenbergMobileRepo, "v"+version)
+}


### PR DESCRIPTION
This moves some search functions and constants related to releases to the `release` package.
Also updates the status command given the above changes 

##Testing 
run the status command on a recent release and inspect the output.