### PR TITLE
Update Release Checklist template for CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,14 +1,20 @@
 # GBM CLI
 
 ## Overview
-The GBM cli tool helps developmental tasks for managing Gutenberg Mobile releases.
+The GBM CLI tool helps developmental tasks for managing Gutenberg Mobile releases.
 
 The current features include:
 - Command to generate the release checklist
 - Commands to wrangle Gutenberg Mobile releases
 
-## Prerequisites
-Download and install the [Go package](https://go.dev/doc/install). 
+## Development Environment
+1. Download and install the [Go package](https://go.dev/doc/install). 
+2. While not required, it is higly recommended to develop with [VSCode](https://code.visualstudio.com/) and install the [Go VSCode](https://marketplace.visualstudio.com/items?itemName=golang.go) extension.
+
+## Releasing
+For detailed instructions on running a release, visit [Releasing.md](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/cli/update-checklist/cli/Releasing.md).
+
+## Testing
 
 
 ## Structure

--- a/cli/README.md
+++ b/cli/README.md
@@ -15,6 +15,8 @@ The current features include:
 For detailed instructions on running a release, visit [Releasing.md](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/cli/update-checklist/cli/Releasing.md).
 
 ## Testing
+For detailed instructions on testing and configuring your development environment, visit [Testing.md](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/cli/update-checklist/cli/Testing.md).
+
 
 
 ## Structure

--- a/cli/Releasing.md
+++ b/cli/Releasing.md
@@ -87,7 +87,6 @@ At the same time there could also be a regular release going on for example for 
 
 ### Automation script differences
 
-1. Before running the script switch to the relevant branch to cut from in gutenberg-mobile repo.
 1. Run the CLI tool as normal
 1. When asked by the script enter the relevant branch names to cut from (to target) in other repos.
 1. If a commit that is fixing the issue is already merged to gutenberg, when asked by the script enter the commit hash to be cherry-picked.

--- a/cli/Releasing.md
+++ b/cli/Releasing.md
@@ -1,0 +1,126 @@
+# Release Checklist Template
+
+The Release Checklist Template can be generated with the following command: (replacing `X.XX.X` with the applicable release number):
+
+```
+go run main.go render checklist -v X.XX.X --message "This hotfix addresses ISSUE_OR_CRASH in ORIGINAL_VERSION. See P2_PR_SLACK_ETC_LINK_OR_LINKS for the rationale behind the decision to make it."
+```
+
+The `--c` flag will copy the output to your clipboard. To view the output in the command line, simply remove the `--c` flag.
+
+
+If the release is a betafix/hotfix, include a message explaining briefly the reason for releasing the fix.
+**Example:** `This hotfix addresses ISSUE_OR_CRASH in ORIGINAL_VERSION. See P2_PR_SLACK_ETC_LINK_OR_LINKS for the rationale behind the decision to make it.`
+
+
+# Different types of releases
+
+## Best practices
+
+It's best practice to use the automation script (mentioned in the release template above) for all releases types (alpha, regular, betafix, hotfix). When wrangling a betafix or hotfix, it's important to merge the fix to Gutenberg `trunk` independently of the release process. When the release is cut (by the automation script) the commit(s) that make up the betafix or hotfix should then be cherry-picked onto the Gutenberg release branch.
+
+## 1. Alpha
+
+### When
+
+Whenever a build is needed for testing (usually a few days prior to a Regular release)
+
+### Branches
+
+For example, when the next release will be `1.11.0`.
+
+| Repo             | Cut From | Branch Name                               |
+| ---------------- | -------- | ----------------------------------------- |
+| gutenberg        | trunk    | rnmobile/release_1.11.0-alpha1            |
+| gutenberg-mobile | trunk    | release/1.11.0-alpha1                     |
+| WPAndroid        | trunk    | gutenberg/integrate_release_1.11.0-alpha1 |
+| WPiOS            | trunk    | gutenberg/integrate_release_1.11.0-alpha1 |
+
+### Automation script differences
+
+Compared to a Regular release, the differences here are:
+
+- When the script asks for the new version number, don't forget to add the `-alpha` suffix (e.g. `1.11.0-alpha1`).
+- All PRs created by the release script should be edited to clarify that they are temporary and will be deleted when testing is finished.
+
+### Release checklist template differences
+
+The release checklist is not used for alpha releases. When testing is finished, please close all PRs and delete all branches created by the script.
+
+## 2. Regular
+
+### When
+
+On Thursdays, the week before the main apps (WPiOS & WPAndroid) have cut their releases, every 2 weeks.
+
+### Branches
+
+For example when releasing gutenberg-mobile `1.11.0`.
+
+| Repo             | Cut From | Branch Name                        | Merging To      |
+| ---------------- | -------- | ---------------------------------- | --------------- |
+| gutenberg        | trunk    | rnmobile/release_1.11.0            | trunk           |
+| gutenberg-mobile | trunk    | release/1.11.0                     | trunk           |
+| WPAndroid        | trunk    | gutenberg/integrate_release_1.11.0 | trunk           |
+| WPiOS            | trunk    | gutenberg/integrate_release_1.11.0 | trunk           |
+
+## 3. Betafix
+
+### When
+
+A fix is targeting a main app version that is not yet released (meaning the release branch is cut but it's still in beta) and a new gutenberg-mobile release is needed.
+
+### Branches
+
+For example when releasing gutenberg-mobile `1.11.1` while main apps version `22.2.0` is in beta which currently has gutenberg-mobile `1.11.0` in it.
+At the same time there could also be a regular release going on for example for gutenberg-mobile version `1.12.0`.
+
+| Repo             | Cut From                | Branch Name                        | Merging To                                                       |
+| ---------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------- |
+| gutenberg        | rnmobile/release_1.11.0 (tag) | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.0                     |
+| gutenberg-mobile | v1.11.0 (tag)          | release/1.11.1                     | trunk & (maybe also) release/1.12.0                              |
+| WPAndroid        | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.0 & (maybe also) gutenberg/integrate_release_1.12.0 |
+| WPiOS            | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.0 & (maybe also) gutenberg/integrate_release_1.12.0 |
+
+### Automation script differences
+
+1. Before running the script switch to the relevant branch to cut from in gutenberg-mobile repo.
+1. Run the CLI tool as normal
+1. When asked by the script enter the relevant branch names to cut from (to target) in other repos.
+1. If a commit that is fixing the issue is already merged to gutenberg, when asked by the script enter the commit hash to be cherry-picked.
+
+### Release checklist template differences
+
+1. Include `Betafix` in the heading.
+1. `after_X.XX.X` branches can be ignored.
+
+## 4. Hotfix
+
+### When
+
+A fix is targeting a main app version that is already released and a new gutenberg-mobile release is needed.
+
+### Branches
+
+For example when releasing gutenberg-mobile `1.11.1` while main apps version `22.2.0` is released which currently has gutenberg-mobile `1.11.0` in it.
+At the same time there could also be a regular release, a betafix or even another hotfix going on for example for gutenberg-mobile version `1.12.1`.
+
+| Repo             | Cut From                | Branch Name                        | Merging To                                                       |
+| ---------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------- |
+| gutenberg        | rnmobile/release_1.11.0 (tag) | rnmobile/release_1.11.1            | trunk & (maybe also) rnmobile/release_1.12.1                     |
+| gutenberg-mobile | v1.11.0 (tag)          | release/1.11.1                     | trunk & (maybe also) release/1.12.1                              |
+| WPAndroid        | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.1 & (maybe also) gutenberg/integrate_release_1.12.1 |
+| WPiOS            | release/22.2.0          | gutenberg/integrate_release_1.11.1 | release/22.2.1 & (maybe also) gutenberg/integrate_release_1.12.1 |
+
+### Automation script differences
+
+1. If necessary create new patch version branches `release/X.Y.1` in WPiOS and WPAndroid.
+
+Rest should be same the as Betafix
+
+### Release checklist template differences
+
+1. Include `Hotfix` in the heading
+1. After the fix is merged and if there is an ongoing regular release, betafix or hotfix then the changes should be brought back to those branches as well.
+
+The rest should be same the as Betafix.

--- a/cli/Releasing.md
+++ b/cli/Releasing.md
@@ -3,15 +3,18 @@
 The Release Checklist Template can be generated with the following command: (replacing `X.XX.X` with the applicable release number):
 
 ```
-go run main.go render checklist -v X.XX.X --message "This hotfix addresses ISSUE_OR_CRASH in ORIGINAL_VERSION. See P2_PR_SLACK_ETC_LINK_OR_LINKS for the rationale behind the decision to make it."
+go run main.go render checklist -v X.XX.X
 ```
 
 The `--c` flag will copy the output to your clipboard. To view the output in the command line, simply remove the `--c` flag.
 
 
 If the release is a betafix/hotfix, include a message explaining briefly the reason for releasing the fix.
-**Example:** `This hotfix addresses ISSUE_OR_CRASH in ORIGINAL_VERSION. See P2_PR_SLACK_ETC_LINK_OR_LINKS for the rationale behind the decision to make it.`
+**Example:** 
 
+```
+go run main.go render checklist -v X.XX.X --message "This hotfix addresses ISSUE_OR_CRASH in ORIGINAL_VERSION. See P2_PR_SLACK_ETC_LINK_OR_LINKS for the rationale behind the decision to make it."
+```
 
 # Different types of releases
 
@@ -23,7 +26,7 @@ It's best practice to use the automation script (mentioned in the release templa
 
 ### When
 
-Whenever a build is needed for testing (usually a few days prior to a Regular release)
+Whenever a build is needed for testing (usually a few days prior to a Regular release).
 
 ### Branches
 
@@ -116,7 +119,7 @@ At the same time there could also be a regular release, a betafix or even anothe
 
 1. If necessary create new patch version branches `release/X.Y.1` in WPiOS and WPAndroid.
 
-Rest should be same the as Betafix
+The rest should be same the as Betafix.
 
 ### Release checklist template differences
 

--- a/cli/Testing.md
+++ b/cli/Testing.md
@@ -6,18 +6,19 @@ If developing with VSCode, tests can be run inline within the test files themsel
 The CLI tool can be run against forked repos for testing. To configure your forked repos:
 
  1. Fork the following repos to your github user repo:
-    a) Gutenberg-Mobile: https://github.com/wordpress-mobile/gutenberg-mobile
-    * .gitmodules on CURRENT_BRANCH should reference your gutenberg fork, replace 'WordPress' with GITHUB_USERNAME
-    * (https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/.gitmodules)
-    b) Gutenberg: https://github.com/WordPress/gutenberg
-    c) WordPress-Android: https://github.com/wordpress-mobile/WordPress-Android
-    d) WordPress-iOS: https://github.com/wordpress-mobile/WordPress-iOS
+    - [Gutenberg-Mobile](https://github.com/wordpress-mobile/gutenberg-mobile)    
+    - [Gutenberg](https://github.com/WordPress/gutenberg)
+    - [WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android)
+    - [WordPress-iOS](https://github.com/wordpress-mobile/WordPress-iOS)
 
-2. Ensure that your forked repos contains the PR labels specified below:
+3. Ensure that your forked repos contains the PR labels specified below:
     a) Gutenberg Mobile: "release-process"
     b) Gutenberg: "Mobile App - i.e. Android or iOS"
 
-3. Ensure that each of your repos contains the target branch `trunk`
+4. Ensure that each of your repos contains the target branch `trunk`.
+
+5. Ensure that [.gitmodules](https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/.gitmodules) references your Gutenberg fork.
+
 
 To run commands against the forked repos, set `GBM_WORDPRESS_ORG` and `GBM_WPMOBILE_ORG` as environment variables to user GitHub username. By default, these values with be WordPress and WordPress-Mobile, respectively.
 

--- a/cli/Testing.md
+++ b/cli/Testing.md
@@ -1,0 +1,29 @@
+# Testing
+
+If developing with VSCode, tests can be run inline within the test files themselves, and is the recommended method for running and debugging tests. Tests can also be run from the command line with the `go test` command.
+
+## Testing Environment for Development
+The CLI tool can be run against forked repos for testing. To configure your forked repos:
+
+ 1. Fork the following repos to your github user repo:
+    a) Gutenberg-Mobile: https://github.com/wordpress-mobile/gutenberg-mobile
+    * .gitmodules on CURRENT_BRANCH should reference your gutenberg fork, replace 'WordPress' with GITHUB_USERNAME
+    * (https://github.com/wordpress-mobile/gutenberg-mobile/blob/trunk/.gitmodules)
+    b) Gutenberg: https://github.com/WordPress/gutenberg
+    c) WordPress-Android: https://github.com/wordpress-mobile/WordPress-Android
+    d) WordPress-iOS: https://github.com/wordpress-mobile/WordPress-iOS
+
+2. Ensure that your forked repos contains the PR labels specified below:
+    a) Gutenberg Mobile: "release-process"
+    b) Gutenberg: "Mobile App - i.e. Android or iOS"
+
+3. Ensure that each of your repos contains the target branch `trunk`
+
+To run commands against the forked repos, set `GBM_WORDPRESS_ORG` and `GBM_WPMOBILE_ORG` as environment variables to user GitHub username. By default, these values with be WordPress and WordPress-Mobile, respectively.
+
+Example command:
+
+```
+GBM_WPMOBILE_ORG=yourusername GBM_WORDPRESS_ORG=yourusername go run main.go release prepare gb 1.109.0 
+```
+

--- a/cli/cmd/render/checklist.go
+++ b/cli/cmd/render/checklist.go
@@ -70,6 +70,7 @@ var ChecklistCmd = &cobra.Command{
 				Scheduled:    scheduled,
 				ReleaseUrl:   releaseUrl,
 				Date:         releaseDate,
+				Message: 	  message,
 				HostVersion:  hostVersion,
 				IncludeAztec: includeAztec,
 				CheckAztec:   checkAztec,

--- a/cli/templates/checklist/checklist.html
+++ b/cli/templates/checklist/checklist.html
@@ -37,13 +37,12 @@
 <h3>Create the Release{{ if .Scheduled }} (Thursday) {{end}}</h3>
 <!-- /wp:heading -->
 
-{{ Task `Verify that <code>gutenberg-mobile/RNTAztecView.podspec</code> and <code>gutenberg-mobile/gutenberg/packages/react-native-aztec/RNTAztecView.podspec</code>
- refer to the same <code>WordPress-Aztec-iOS</code> version and are pointing to a stable, tagged release (e.g. 1.14.1). If they are not, we may need to <a href="#create-a-new-aztec-release">create a new Aztec</a> release.` }}
+{{ Task `Clone the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile">CLI</a> or pull the latest version if you have already cloned it.` }}
 
-{{ Task `Clone the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile">release scripts</a> or pull the latest version if you have already cloned it.` }}
+{{ Task `Review the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/develop/cli/Releasing.md">release script instructions</a>.
+In your clone of the release scripts <code>cli</code> directory, run the prepare command:  <code>go run main.go release prepare all %s</code>. This creates the gutenberg and gutenberg-mobile release PRs.` }}
 
-{{ Task `Review the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/develop/Releasing.md">release script instructions</a>.
- In your clone of the release scripts, run the script via:  <code>./release_automation.sh</code>. This creates the gutenberg and gutenberg-mobile release PRs as well as WPAndroid and WPiOS integration PRs.` }}
+{{ Task `Once the CI tasks succeed, run the integrate command to create the main apps PRs for WordPress-iOS and WordPress-Android: <code>go run main.go release integrate %s</code> `}}
 
 {{ if .Scheduled }}
 <!-- wp:group -->
@@ -59,17 +58,6 @@
 </div>
 <!-- /wp:group -->
 {{ end }}
-
-{{ Task `In both <code>RELEASE-NOTES.txt</code> and <code>gutenberg/packages/react-native-editor/CHANGELOG.md</code>,
- replace <code>Unreleased</code> section with the release version and create a new <code>Unreleased</code> section.` }}
-
-{{ Task `Review and update <code>RELEASE-NOTES.txt</code> file on both WPAndroid and WPiOS PRs so it includes all user-facing changes introduced in the release.
- Keep in mind that some changes can be specific to a single platform, so they should only be added to the release notes of the platform that affects
- (e.g. a change that only affects Android should only be included in WPAndroid release notes).` }}
-
-{{ Task `Verify the WPAndroid and WPiOS PR builds succeed. For WPAndroid, if the PR CI tasks include a 403 error related to an inability to resolve the
- <code>react-native-bridge</code> dependency, you must wait for the <code>Build Android RN Bridge &amp; Publish to S3</code>
- task to succeed in gutenberg-mobile and then restart the WPAndroid CI tasks. Similarly, for iOS, you must wait for the <code>Build iOS RN XCFramework &amp; Publish to S3</code> task to succeed.` }}
 
 {{ Task `Once the installable builds are ready, perform a quick smoke test of the editor on both iOS and Android to verify it launches without crashing.
 We will perform additional testing after the main apps cut their releases.` }}
@@ -112,14 +100,8 @@ and don't forget to run <code>npm run bundle</code> in gutenberg-mobile again if
 {{ Task `Add the new change to the "Extra PRs that Landed After the Release Was Cut" section of the gutenberg-mobile PR description.` }}
 
 <!-- wp:heading {"level":3} -->
-<h3>Integrate the Release{{ if .Scheduled }} (Thursday) {{end}}</h3>
+<h3>Publish the Release{{ if .Scheduled }} (Thursday) {{end}}</h3>
 <!-- /wp:heading -->
-
-{{ Task `Verify the <code>gutenberg</code> ref within the gutenberg-mobile release branch is pointed to the latest commit in the gutenberg release branch.` }}
-
-{{ Task `Create and push a <code>rnmobile/%s</code> git tag for the head of gutenberg release branch.` .Version }}
-
-{{ Task `Ensure that the bundle files are updated to include any changes to the release branch by running <code>npm run bundle</code> in gutenberg-mobile release branch and committing any changes.` }}
 
 {{ Task `<a href="%s">Create a new gutenberg-mobile GitHub Release</a>. Include a list of changes in the release description. Ensure the checkmark "Set as the latest release" is checked, and <strong>publish the release with the "Publish release" button.</strong>` .ReleaseUrl }}
 

--- a/cli/templates/checklist/checklist.html
+++ b/cli/templates/checklist/checklist.html
@@ -37,7 +37,7 @@
 <h3>Create the Release{{ if .Scheduled }} (Thursday) {{end}}</h3>
 <!-- /wp:heading -->
 
-{{ Task `Clone the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile">CLI</a> or pull the latest version if you have already cloned it.` }}
+{{ Task `Pull the latest version of the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases">CLI</a>.` }}
 
 {{ Task `Review the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/develop/cli/Releasing.md">release script instructions</a>.
 In your clone of the release scripts <code>cli</code> directory, run the prepare command:  <code>go run main.go release prepare all %s</code>. This creates the gutenberg and gutenberg-mobile release PRs.` }}

--- a/cli/templates/checklist/checklist.html
+++ b/cli/templates/checklist/checklist.html
@@ -39,8 +39,7 @@
 
 {{ Task `Pull the latest version of the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases">CLI</a>.` }}
 
-{{ Task `Review the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/develop/cli/Releasing.md">release script instructions</a>.
-In your clone of the release scripts <code>cli</code> directory, run the prepare command:  <code>go run main.go release prepare all %s</code>. This creates the gutenberg and gutenberg-mobile release PRs.` }}
+{{ Task `In your clone of the <code>cli</code> directory, run the prepare command: <code>go run main.go release prepare all %s</code> to create the gutenberg and gutenberg-mobile release PRs.` }}
 
 {{ Task `Once the CI tasks succeed, run the integrate command to create the main apps PRs for WordPress-iOS and WordPress-Android: <code>go run main.go release integrate %s</code> `}}
 


### PR DESCRIPTION
Updates the Release Checklist template for the new (and unused) steps to follow the new CLI tool process.

We can continue updating the template as we automate steps.

* https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/194