### PR TITLE
Add prompt logic to handle if branch already exists

### DIFF
--- a/cli/pkg/gh/gh.go
+++ b/cli/pkg/gh/gh.go
@@ -140,6 +140,17 @@ func SearchBranch(rpo, branch string) (Branch, error) {
 	return response, nil
 }
 
+func DeleteBranch(rpo, branch string) error {
+	org := repo.GetOrg(rpo)
+	if org == "" {
+		return fmt.Errorf("unable to get org for %s", rpo)
+	}
+	response := Branch{}
+	client := getClient()
+	endpoint := fmt.Sprintf("repos/%s/%s/git/refs/heads/%s", org, rpo, branch)
+	return client.Delete(endpoint, &response)
+}
+
 // SearchPrs returns a list of PRs for the given repo and filter.
 func SearchPrs(filter RepoFilter) (SearchResult, error) {
 	client := getClient()

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -27,28 +27,32 @@ func CreateGbPR(version, dir string, noTag bool) (gh.PullRequest, error) {
 	if (exists != gh.Branch{}) {
 		console.Warn("Branch %s already exists", branch)
 
-		cont := console.Confirm("Do you wish to continue?")
+		cont := console.Confirm("Do you wish to continue? (The remote branch will be deleted.)")
 
 		if !cont {
 			console.Info("Bye 👋")
 			return pr, fmt.Errorf("exiting before creating PR")
 		}
-		return pr, fmt.Errorf("existing branch not implemented yet")
-	} else {
-		console.Info("Cloning Gutenberg to %s", dir)
 
-		// Let's clone into the current directory so that the git client can find the .git directory
-		err := git.Clone(repo.GetRepoPath("gutenberg"), "--depth=1", ".")
-
-		if err != nil {
-			return pr, fmt.Errorf("error cloning the Gutenberg repository: %v", err)
+		// Delete the branch on the GitHub repo
+		if err := gh.DeleteBranch("gutenberg", branch); err != nil {
+			return pr, fmt.Errorf("error deleting the branch: %v", err)
 		}
+	}
 
-		console.Info("Checking out branch %s", branch)
-		err = git.Switch("-c", branch)
-		if err != nil {
-			return pr, fmt.Errorf("error checking out the branch: %v", err)
-		}
+	console.Info("Cloning Gutenberg to %s", dir)
+
+	// Let's clone into the current directory so that the git client can find the .git directory
+	err := git.Clone(repo.GetRepoPath("gutenberg"), "--depth=1", ".")
+
+	if err != nil {
+		return pr, fmt.Errorf("error cloning the Gutenberg repository: %v", err)
+	}
+
+	console.Info("Checking out branch %s", branch)
+	err = git.Switch("-c", branch)
+	if err != nil {
+		return pr, fmt.Errorf("error checking out the branch: %v", err)
 	}
 
 	console.Info("Updating package versions")

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -37,19 +37,30 @@ func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
 
 	if (exists != gh.Branch{}) {
 		console.Info("Branch %s already exists", branch)
-		return pr, nil
-	} else {
-		console.Info("Cloning Gutenberg Mobile to %s", dir)
-		err := git.Clone(repo.GetRepoPath("gutenberg-mobile"), "--depth=1", "--recursive", ".")
-		if err != nil {
-			return pr, fmt.Errorf("error cloning the Gutenberg Mobile repository: %v", err)
+		
+		cont := console.Confirm("Do you wish to continue? (The remote branch will be deleted.)")
+
+		if !cont {
+			console.Info("Bye 👋")
+			return pr, fmt.Errorf("exiting before creating PR")
 		}
 
-		console.Info("Checking out branch %s", branch)
-		err = git.Switch("-c", branch)
-		if err != nil {
-			return pr, fmt.Errorf("error checking out the branch: %v", err)
+		// Delete the branch on the GitHub repo
+		if err := gh.DeleteBranch("gutenberg-mobile", branch); err != nil {
+			return pr, fmt.Errorf("error deleting the branch: %v", err)
 		}
+	}
+
+	console.Info("Cloning Gutenberg Mobile to %s", dir)
+	err := git.Clone(repo.GetRepoPath("gutenberg-mobile"), "--depth=1", "--recursive", ".")
+	if err != nil {
+		return pr, fmt.Errorf("error cloning the Gutenberg Mobile repository: %v", err)
+	}
+
+	console.Info("Checking out branch %s", branch)
+	err = git.Switch("-c", branch)
+	if err != nil {
+		return pr, fmt.Errorf("error checking out the branch: %v", err)
 	}
 
 	// Update the Gutenberg submodule


### PR DESCRIPTION
Resolves:
* https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/209

When running the `go run main.go release prepare all x.xx.x` command and the branch already exists on the remote repo, the user is prompted if they want to continue. This PR adds the logic to delete the remote branch and continue cloning:

#### PR Changes
- Adds `DeleteBranch` GitHub interface
- When running `prepare`, moves `git.Clone` commands outside of the `else` statement to continue the automation (and for DRY-ness)

#### To test
1. Create a release, e.g. `go run main.go release prepare all 1.108.0`
2. Once the PR is created and the branch exists on the remote repo, run the same command again
3. At the prompt, choose either  yes _(continue)_ or no _(exit)_
4. If yes _(continue)_, the remote branch should be deleted and the script resumes cloning the repo
5. If no _(exit)_, the script should stop running and the remote branch remains