### PR TITLE
[CLI] Add support for preparing GB patch releases

### DIFF
--- a/cli/cmd/release/prepare/all.go
+++ b/cli/cmd/release/prepare/all.go
@@ -33,13 +33,13 @@ var allCmd = &cobra.Command{
 
 		console.Info("Preparing Gutenberg for release %s", version)
 
-		gbPr, err = release.CreateGbPR(version, gbDir, noTag)
+		gbPr, err = release.CreateGbPR(version.String(), gbDir, noTag)
 		exitIfError(err, 1)
 		console.Info("Finished preparing Gutenberg PR")
 
 		console.Info("Preparing Gutenberg Mobile for release %s", version)
 
-		pr, err := release.CreateGbmPR(version, gbmDir)
+		pr, err := release.CreateGbmPR(version.String(), gbmDir)
 		exitIfError(err, 1)
 		console.Info("Finished preparing Gutenberg Mobile PR")
 

--- a/cli/cmd/release/prepare/all.go
+++ b/cli/cmd/release/prepare/all.go
@@ -32,14 +32,23 @@ var allCmd = &cobra.Command{
 		gbPr := gh.PullRequest{}
 
 		console.Info("Preparing Gutenberg for release %s", version)
+		build := release.Build{
+			Dir:     gbDir,
+			Version: version,
+			Tag:     !noTag,
+		}
 
-		gbPr, err = release.CreateGbPR(version.String(), gbDir, noTag)
+		gbPr, err = release.CreateGbPR(build)
 		exitIfError(err, 1)
 		console.Info("Finished preparing Gutenberg PR")
 
 		console.Info("Preparing Gutenberg Mobile for release %s", version)
 
-		pr, err := release.CreateGbmPR(version.String(), gbmDir)
+		build = release.Build{
+			Dir:     gbmDir,
+			Version: version,
+		}
+		pr, err := release.CreateGbmPR(build)
 		exitIfError(err, 1)
 		console.Info("Finished preparing Gutenberg Mobile PR")
 

--- a/cli/cmd/release/prepare/all.go
+++ b/cli/cmd/release/prepare/all.go
@@ -36,6 +36,9 @@ var allCmd = &cobra.Command{
 			Dir:     gbDir,
 			Version: version,
 			UseTag:  !noTag,
+			Base: gh.Repo{
+				Ref: "trunk",
+			},
 		}
 
 		gbPr, err = release.CreateGbPR(build)

--- a/cli/cmd/release/prepare/all.go
+++ b/cli/cmd/release/prepare/all.go
@@ -35,7 +35,7 @@ var allCmd = &cobra.Command{
 		build := release.Build{
 			Dir:     gbDir,
 			Version: version,
-			Tag:     !noTag,
+			UseTag:  !noTag,
 		}
 
 		gbPr, err = release.CreateGbPR(build)

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -1,8 +1,11 @@
 package prepare
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 )
 
@@ -12,19 +15,27 @@ var gbCmd = &cobra.Command{
 	Long:  `Use this command to prepare a Gutenberg release PR`,
 	Run: func(cc *cobra.Command, args []string) {
 		preflight(args)
+
 		defer workspace.Cleanup()
-
-		if version.IsPatchRelease() {
-			console.Info("Preparing Gutenberg for patch release %s", version)
-		}
-
-		console.Info("Preparing Gutenberg for release %s", version)
-
 		build := release.Build{
 			Dir:     tempDir,
 			Version: version,
 			Tag:     !noTag,
 		}
+
+		if version.IsPatchRelease() {
+			console.Info("Preparing Gutenberg for patch release %s", version)
+			build.Prs = gh.GetPrs("gutenberg", prs)
+
+			if len(build.Prs) == 0 {
+				exitIfError(errors.New("no PRs found for patch release"), 1)
+				return
+			}
+
+			exitIfError(errors.New("not implemented yet"), 1)
+		}
+
+		console.Info("Preparing Gutenberg for release %s", version)
 
 		pr, err := release.CreateGbPR(build)
 		exitIfError(err, 1)

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -16,7 +16,7 @@ var gbCmd = &cobra.Command{
 
 		console.Info("Preparing Gutenberg for release %s", version)
 
-		pr, err := release.CreateGbPR(version, tempDir, noTag)
+		pr, err := release.CreateGbPR(version.String(), tempDir, noTag)
 		exitIfError(err, 1)
 
 		console.Info("Created PR %s", pr.Url)

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -21,16 +21,12 @@ var gbCmd = &cobra.Command{
 			Dir:     tempDir,
 			Version: version,
 			Tag:     !noTag,
+			Base:    gh.Repo{Ref: "trunk"},
 		}
 
 		if version.IsPatchRelease() {
 			console.Info("Preparing Gutenberg for patch release %s", version)
-			build.Prs = gh.GetPrs("gutenberg", prs)
-
-			if len(build.Prs) == 0 {
-				exitIfError(errors.New("no PRs found for patch release"), 1)
-				return
-			}
+			setupPatchBuild(&build)
 
 			exitIfError(errors.New("not implemented yet"), 1)
 		}

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -14,9 +14,19 @@ var gbCmd = &cobra.Command{
 		preflight(args)
 		defer workspace.Cleanup()
 
+		if version.IsPatchRelease() {
+			console.Info("Preparing Gutenberg for patch release %s", version)
+		}
+
 		console.Info("Preparing Gutenberg for release %s", version)
 
-		pr, err := release.CreateGbPR(version.String(), tempDir, noTag)
+		build := release.Build{
+			Dir:     tempDir,
+			Version: version,
+			Tag:     !noTag,
+		}
+
+		pr, err := release.CreateGbPR(build)
 		exitIfError(err, 1)
 
 		console.Info("Created PR %s", pr.Url)

--- a/cli/cmd/release/prepare/gb.go
+++ b/cli/cmd/release/prepare/gb.go
@@ -1,8 +1,6 @@
 package prepare
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
@@ -20,15 +18,15 @@ var gbCmd = &cobra.Command{
 		build := release.Build{
 			Dir:     tempDir,
 			Version: version,
-			Tag:     !noTag,
-			Base:    gh.Repo{Ref: "trunk"},
+			UseTag:  !noTag,
+			Base: gh.Repo{
+				Ref: "trunk",
+			},
 		}
 
 		if version.IsPatchRelease() {
-			console.Info("Preparing Gutenberg for patch release %s", version)
+			console.Info("Preparing a patch release")
 			setupPatchBuild(&build)
-
-			exitIfError(errors.New("not implemented yet"), 1)
 		}
 
 		console.Info("Preparing Gutenberg for release %s", version)

--- a/cli/cmd/release/prepare/gbm.go
+++ b/cli/cmd/release/prepare/gbm.go
@@ -16,7 +16,12 @@ var gbmCmd = &cobra.Command{
 
 		console.Info("Preparing Gutenberg Mobile for release %s", version)
 
-		pr, err := release.CreateGbmPR(version.String(), tempDir)
+		build := release.Build{
+			Dir:     tempDir,
+			Version: version,
+		}
+
+		pr, err := release.CreateGbmPR(build)
 		exitIfError(err, 1)
 
 		console.Info("Created PR %s", pr.Url)

--- a/cli/cmd/release/prepare/gbm.go
+++ b/cli/cmd/release/prepare/gbm.go
@@ -16,7 +16,7 @@ var gbmCmd = &cobra.Command{
 
 		console.Info("Preparing Gutenberg Mobile for release %s", version)
 
-		pr, err := release.CreateGbmPR(version, tempDir)
+		pr, err := release.CreateGbmPR(version.String(), tempDir)
 		exitIfError(err, 1)
 
 		console.Info("Created PR %s", pr.Url)

--- a/cli/cmd/release/prepare/gbm.go
+++ b/cli/cmd/release/prepare/gbm.go
@@ -3,6 +3,7 @@ package prepare
 import (
 	"github.com/spf13/cobra"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 )
 
@@ -19,6 +20,9 @@ var gbmCmd = &cobra.Command{
 		build := release.Build{
 			Dir:     tempDir,
 			Version: version,
+			Base: gh.Repo{
+				Ref: "trunk",
+			},
 		}
 
 		pr, err := release.CreateGbmPR(build)

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -73,8 +73,12 @@ func setupPatchBuild(build *release.Build) {
 	// Get the ref to the prior release
 	priorVersion := version.PriorVersion()
 
+	tag, err := gh.GetTag("gutenberg", "rnmobile/"+priorVersion.String())
+	exitIfError(err, 1)
+
 	build.Base = gh.Repo{Ref: "rnmobile/" + priorVersion.String()}
 	build.Prs = gh.GetPrs("gutenberg", prs)
+	build.Depth = "--shallow-since=" + tag.Date
 
 	if len(build.Prs) == 0 {
 		exitIfError(errors.New("no PRs found for patch release"), 1)

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -63,7 +63,7 @@ func init() {
 	PrepareCmd.AddCommand(gbmCmd)
 	PrepareCmd.AddCommand(gbCmd)
 	PrepareCmd.AddCommand(allCmd)
-	PrepareCmd.PersistentFlags().BoolVar(&keepTempDir, "k", false, "Keep temporary directory after running command")
+	PrepareCmd.PersistentFlags().BoolVar(&keepTempDir, "keep", false, "Keep temporary directory after running command")
 	PrepareCmd.PersistentFlags().BoolVar(&noTag, "no-tag", false, "Prevent tagging the release")
 	PrepareCmd.PersistentFlags().StringSliceVar(&prs, "prs", []string{}, "prs to include in the release. Only used with patch releases")
 }

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -74,12 +74,10 @@ func setupPatchBuild(build *release.Build) {
 	priorVersion := version.PriorVersion()
 
 	build.Base = gh.Repo{Ref: "rnmobile/" + priorVersion.String()}
-
 	build.Prs = gh.GetPrs("gutenberg", prs)
 
 	if len(build.Prs) == 0 {
 		exitIfError(errors.New("no PRs found for patch release"), 1)
 		return
 	}
-
 }

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -8,6 +8,8 @@ import (
 	wp "github.com/wordpress-mobile/gbm-cli/cmd/workspace"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/release"
 	"github.com/wordpress-mobile/gbm-cli/pkg/semver"
 )
 
@@ -64,4 +66,20 @@ func init() {
 	PrepareCmd.PersistentFlags().BoolVar(&keepTempDir, "k", false, "Keep temporary directory after running command")
 	PrepareCmd.PersistentFlags().BoolVar(&noTag, "no-tag", false, "Prevent tagging the release")
 	PrepareCmd.PersistentFlags().StringArrayVar(&prs, "prs", []string{}, "prs to include in the release. Only used with patch releases")
+}
+
+func setupPatchBuild(build *release.Build) {
+
+	// Get the ref to the prior release
+	priorVersion := version.PriorVersion()
+
+	build.Base = gh.Repo{Ref: "rnmobile/" + priorVersion.String()}
+
+	build.Prs = gh.GetPrs("gutenberg", prs)
+
+	if len(build.Prs) == 0 {
+		exitIfError(errors.New("no PRs found for patch release"), 1)
+		return
+	}
+
 }

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -65,7 +65,7 @@ func init() {
 	PrepareCmd.AddCommand(allCmd)
 	PrepareCmd.PersistentFlags().BoolVar(&keepTempDir, "k", false, "Keep temporary directory after running command")
 	PrepareCmd.PersistentFlags().BoolVar(&noTag, "no-tag", false, "Prevent tagging the release")
-	PrepareCmd.PersistentFlags().StringArrayVar(&prs, "prs", []string{}, "prs to include in the release. Only used with patch releases")
+	PrepareCmd.PersistentFlags().StringSliceVar(&prs, "prs", []string{}, "prs to include in the release. Only used with patch releases")
 }
 
 func setupPatchBuild(build *release.Build) {

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -16,6 +16,7 @@ var keepTempDir, noTag bool
 var workspace wp.Workspace
 var tempDir string
 var version semver.SemVer
+var prs []string
 
 var PrepareCmd = &cobra.Command{
 	Use:   "prepare",
@@ -62,5 +63,5 @@ func init() {
 	PrepareCmd.AddCommand(allCmd)
 	PrepareCmd.PersistentFlags().BoolVar(&keepTempDir, "k", false, "Keep temporary directory after running command")
 	PrepareCmd.PersistentFlags().BoolVar(&noTag, "no-tag", false, "Prevent tagging the release")
-
+	PrepareCmd.PersistentFlags().StringArrayVar(&prs, "prs", []string{}, "prs to include in the release. Only used with patch releases")
 }

--- a/cli/cmd/release/prepare/root.go
+++ b/cli/cmd/release/prepare/root.go
@@ -8,12 +8,14 @@ import (
 	wp "github.com/wordpress-mobile/gbm-cli/cmd/workspace"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gbm"
+	"github.com/wordpress-mobile/gbm-cli/pkg/semver"
 )
 
 var exitIfError func(error, int)
 var keepTempDir, noTag bool
 var workspace wp.Workspace
-var tempDir, version string
+var tempDir string
+var version semver.SemVer
 
 var PrepareCmd = &cobra.Command{
 	Use:   "prepare",
@@ -31,9 +33,8 @@ func preflight(args []string) {
 	var err error
 	tempDir = workspace.Dir()
 
-	semver, err := utils.GetVersionArg(args)
+	version, err = utils.GetVersionArg(args)
 	exitIfError(err, 1)
-	version = semver.String()
 
 	// Validate Aztec version
 	if valid := gbm.ValidateAztecVersions(); !valid {

--- a/cli/pkg/console/console.go
+++ b/cli/pkg/console/console.go
@@ -17,6 +17,7 @@ var (
 	Heading    *color.Color
 	HeadingRow *color.Color
 	Row        *color.Color
+	Highlight  *color.Color
 )
 
 func init() {
@@ -24,6 +25,7 @@ func init() {
 	Heading = color.New(color.FgWhite, color.Bold)
 	HeadingRow = color.New(color.FgGreen, color.Bold)
 	Row = color.New(color.FgGreen)
+	Highlight = color.New(color.FgHiWhite)
 }
 
 // Deprecated
@@ -123,4 +125,17 @@ func Confirm(ask string) bool {
 			return false
 		}
 	}
+}
+
+func Ask(ask string) string {
+	reader := bufio.NewReader(os.Stdin)
+
+	l.Printf("%s: ", ask)
+
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return strings.TrimSpace(response)
 }

--- a/cli/pkg/console/console.go
+++ b/cli/pkg/console/console.go
@@ -1,7 +1,6 @@
 package console
 
 import (
-	"bufio"
 	"fmt"
 	"log"
 	"os"
@@ -107,32 +106,27 @@ func Error(err error) {
 }
 
 func Confirm(ask string) bool {
-	reader := bufio.NewReader(os.Stdin)
+	var response string
+	fmt.Print(Highlight.Sprintf("%s [y/n]: ", ask))
 
-	for {
-		l.Printf("%s [y/n]: ", ask)
-
-		response, err := reader.ReadString('\n')
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		response = strings.ToLower(strings.TrimSpace(response))
-
-		if response == "y" || response == "yes" {
-			return true
-		} else if response == "n" || response == "no" {
-			return false
-		}
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		log.Fatal(err)
 	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+
+	if response == "y" || response == "yes" {
+		return true
+	}
+	return false
 }
 
 func Ask(ask string) string {
-	reader := bufio.NewReader(os.Stdin)
+	var response string
+	fmt.Print(Highlight.Sprintf("%s: ", ask))
 
-	l.Printf("%s: ", ask)
-
-	response, err := reader.ReadString('\n')
+	_, err := fmt.Scanln(&response)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cli/pkg/gh/gh.go
+++ b/cli/pkg/gh/gh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/api"
@@ -214,6 +215,23 @@ func GetPr(rpo string, number int) (PullRequest, error) {
 	}
 	pr.Repo = rpo
 	return pr, nil
+}
+
+func GetPrs(rpo string, numbers []string) (prs []PullRequest) {
+	for _, n := range numbers {
+		num, err := strconv.Atoi(n)
+		if err != nil {
+			console.Warn("Skipping PR %s, not a valid number", n)
+			continue
+		}
+
+		if pr, err := GetPr(rpo, num); err != nil {
+			console.Warn("Skipping PR %d, %s", num, err)
+		} else {
+			prs = append(prs, pr)
+		}
+	}
+	return prs
 }
 
 func CreatePr(rpo string, pr *PullRequest) error {

--- a/cli/pkg/gh/gh.go
+++ b/cli/pkg/gh/gh.go
@@ -56,6 +56,7 @@ type PullRequest struct {
 	Head               Repo
 	Base               Repo
 	RequestedReviewers []User `json:"requested_reviewers"`
+	MergeCommit        string `json:"merge_commit_sha"`
 
 	// This field is not part of the GH api but is useful
 	// to get the context of the PR when passing it around
@@ -101,6 +102,14 @@ type Release struct {
 	Prerelease  bool
 	Target      string `json:"target_commitish"`
 	PublishedAt string `json:"published_at"`
+}
+
+type Commit struct {
+	Sha    string
+	Url    string
+	Commit struct {
+		Message string
+	}
 }
 
 // Build a RepoFilter from a repo name and a list of queries.

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -70,8 +70,12 @@ func CreateGbPR(build Build) (gh.PullRequest, error) {
 			if err := git.CherryPick(pr.MergeCommit); err != nil {
 
 				console.Print(console.Highlight, "\nThere was an issue cherry picking PR #%d", pr.Number)
-				console.Print(console.HeadingRow, "\nThe conflict can be resolved by inspecting the following files:")
 				conflicts, err := git.StatConflicts()
+				if len(conflicts) == 0 {
+					return pr, fmt.Errorf("error cherry picking PR %d: %v", pr.Number, err)
+				}
+				console.Print(console.HeadingRow, "\nThe conflict can be resolved by inspecting the following files:")
+
 				if err != nil {
 					return pr, fmt.Errorf("error getting the list of conflicting files: %v", err)
 				}

--- a/cli/pkg/release/gb.go
+++ b/cli/pkg/release/gb.go
@@ -12,8 +12,10 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/pkg/utils"
 )
 
-func CreateGbPR(version, dir string, noTag bool) (gh.PullRequest, error) {
+func CreateGbPR(build Build) (gh.PullRequest, error) {
 	var pr gh.PullRequest
+	version := build.Version.String()
+	dir := build.Dir
 
 	shellProps := shell.CmdProps{Dir: dir, Verbose: true}
 	git := shell.NewGitCmd(shellProps)
@@ -144,7 +146,7 @@ func CreateGbPR(version, dir string, noTag bool) (gh.PullRequest, error) {
 		return pr, fmt.Errorf("pr was not created successfully")
 	}
 
-	if !noTag {
+	if build.Tag {
 		console.Info("Adding release tag")
 		if err := git.PushTag("rnmobile/" + version); err != nil {
 			console.Warn("Error tagging the release: %v", err)

--- a/cli/pkg/release/gbm.go
+++ b/cli/pkg/release/gbm.go
@@ -17,8 +17,10 @@ import (
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 )
 
-func CreateGbmPR(version, dir string) (gh.PullRequest, error) {
+func CreateGbmPR(build Build) (gh.PullRequest, error) {
 	var pr gh.PullRequest
+	version := build.Version.String()
+	dir := build.Dir
 
 	sp := shell.CmdProps{Dir: dir, Verbose: true}
 	git := shell.NewGitCmd(sp)

--- a/cli/pkg/release/main.go
+++ b/cli/pkg/release/main.go
@@ -1,0 +1,21 @@
+package release
+
+import (
+	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/semver"
+)
+
+type Build struct {
+	Version semver.SemVer
+	Dir     string
+	UseTag  bool
+	Prs     []gh.PullRequest
+	Base    gh.Repo
+}
+
+type ReleaseChanges struct {
+	Title  string
+	Number int
+	PrUrl  string
+	Issues []string
+}

--- a/cli/pkg/release/main.go
+++ b/cli/pkg/release/main.go
@@ -11,6 +11,7 @@ type Build struct {
 	UseTag  bool
 	Prs     []gh.PullRequest
 	Base    gh.Repo
+	Depth   string
 }
 
 type ReleaseChanges struct {

--- a/cli/pkg/release/search.go
+++ b/cli/pkg/release/search.go
@@ -3,7 +3,6 @@ package release
 import (
 	"fmt"
 
-	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
 	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
 )
@@ -39,7 +38,6 @@ func FindAndroidReleasePr(version string) (gh.PullRequest, error) {
 	title := fmt.Sprintf(IntegratePrTitle+" in:title", version)
 
 	filter := gh.BuildRepoFilter(repo.WordPressAndroidRepo, "is:pr", label, title)
-	console.Debug(filter.QueryString)
 
 	return gh.SearchPr(filter)
 }

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -219,7 +219,10 @@ func openInEditor(dir string, files []string) error {
 	}
 
 	if editor == "" {
-		console.Warn("No editor set. Manually edit the files before continuing")
+		console.Warn("No editor set. Manually edit or verify the following files before continuing:")
+		for _, f := range files {
+			console.Print(console.Row, f)
+		}
 		return nil
 	}
 	if open := console.Confirm(fmt.Sprintf("\nOpen '%s' with `%s`?", fileArgs, editor)); !open {

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -10,23 +10,7 @@ import (
 
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
-	"github.com/wordpress-mobile/gbm-cli/pkg/semver"
 )
-
-type Build struct {
-	Version semver.SemVer
-	Dir     string
-	Tag     bool
-	Prs     []gh.PullRequest
-	Base    gh.Repo
-}
-
-type ReleaseChanges struct {
-	Title  string
-	Number int
-	PrUrl  string
-	Issues []string
-}
 
 func CollectReleaseChanges(version string, changelog, relnotes []byte) ([]ReleaseChanges, error) {
 	changesRe := regexp.MustCompile(`(?s)\d+\.\d+\.\d+(.*?)\d+\.\d+\.\d+`)

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -231,7 +231,6 @@ func openInEditor(dir string, files []string) error {
 		files[i] = filepath.Join(dir, f)
 	}
 	cmd := exec.Command(editor, files...)
-	console.Debug(cmd.String())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -8,8 +8,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/repo"
+	"github.com/wordpress-mobile/gbm-cli/pkg/shell"
 )
 
 func CollectReleaseChanges(version string, changelog, relnotes []byte) ([]ReleaseChanges, error) {
@@ -184,4 +187,22 @@ func readWriteNotes(version, path string, updater func(string, []byte) []byte) e
 		return err
 	}
 	return nil
+}
+
+func previewPr(rpo, dir, branchFrom string, pr gh.PullRequest) {
+	org := repo.GetOrg(rpo)
+	row := console.Row
+
+	console.Print(console.Heading, "\nPr Preview")
+
+	white := color.New(color.FgWhite).SprintFunc()
+
+	console.Print(row, "Repo: %s/%s", white(org), white(rpo))
+	console.Print(row, "Title: %s", white(pr.Title))
+	console.Print(row, "Body:\n%s", white(pr.Body))
+	console.Print(row, "Commits:")
+
+	git := shell.NewGitCmd(shell.CmdProps{Dir: dir, Verbose: true})
+
+	git.Log(branchFrom+"...HEAD", "--oneline", "--no-merges", "-10")
 }

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -18,6 +18,7 @@ type Build struct {
 	Dir     string
 	Tag     bool
 	Prs     []gh.PullRequest
+	Base    gh.Repo
 }
 
 type ReleaseChanges struct {

--- a/cli/pkg/release/utils.go
+++ b/cli/pkg/release/utils.go
@@ -10,7 +10,15 @@ import (
 
 	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 	"github.com/wordpress-mobile/gbm-cli/pkg/gh"
+	"github.com/wordpress-mobile/gbm-cli/pkg/semver"
 )
+
+type Build struct {
+	Version semver.SemVer
+	Dir     string
+	Tag     bool
+	Prs     []gh.PullRequest
+}
 
 type ReleaseChanges struct {
 	Title  string

--- a/cli/pkg/semver/semver.go
+++ b/cli/pkg/semver/semver.go
@@ -11,7 +11,7 @@ type semver struct {
 type SemVer interface {
 	String() string
 	Vstring() string
-	PriorVersion() string
+	PriorVersion() SemVer
 	IsScheduledRelease() bool
 	IsPatchRelease() bool
 	Parse(version string) error
@@ -31,11 +31,16 @@ func (s *semver) Vstring() string {
 	return fmt.Sprintf("v%d.%d.%d", s.Major, s.Minor, s.Patch)
 }
 
-func (s *semver) PriorVersion() string {
+func (s *semver) PriorVersion() SemVer {
+	var p SemVer
+
+	// ignore errors here because we know the version is valid
 	if s.IsPatchRelease() {
-		return fmt.Sprintf("%d.%d.%d", s.Major, s.Minor, s.Patch-1)
+		p, _ = NewSemVer(fmt.Sprintf("%d.%d.%d", s.Major, s.Minor, s.Patch-1))
+		return p
 	}
-	return fmt.Sprintf("%d.%d.%d", s.Major, s.Minor-1, 0)
+	p, _ = NewSemVer(fmt.Sprintf("%d.%d.%d", s.Major, s.Minor-1, 0))
+	return p
 }
 
 func (s *semver) IsScheduledRelease() bool {

--- a/cli/pkg/semver/semver_test.go
+++ b/cli/pkg/semver/semver_test.go
@@ -24,7 +24,7 @@ func TestSemVer(t *testing.T) {
 	t.Run("It returns the prior version of patch release", func(t *testing.T) {
 		semver, err := NewSemVer("1.0.1")
 		assertNotError(t, err)
-		assertEqual(t, semver.PriorVersion(), "1.0.0")
+		assertEqual(t, semver.PriorVersion().String(), "1.0.0")
 	})
 
 	t.Run("It can determine a scheduled release", func(t *testing.T) {

--- a/cli/pkg/shell/cmds.go
+++ b/cli/pkg/shell/cmds.go
@@ -13,6 +13,7 @@ type CmdProps struct {
 type client struct {
 	cmd       func(...string) error
 	cmdInPath func(string, ...string) error
+	dir       string
 }
 
 func execute(cmd *exec.Cmd, dir string, verbose bool) error {
@@ -34,6 +35,7 @@ func NewNpmCmd(cp CmdProps) NpmCmds {
 			cmd := exec.Command("npm", cmds...)
 			return execute(cmd, path, cp.Verbose)
 		},
+		dir: cp.Dir,
 	}
 }
 
@@ -47,6 +49,7 @@ func NewGitCmd(cp CmdProps) GitCmds {
 			cmd := exec.Command("git", cmds...)
 			return execute(cmd, path, cp.Verbose)
 		},
+		dir: cp.Dir,
 	}
 }
 
@@ -60,6 +63,7 @@ func NewBundlerCmd(cp CmdProps) BundlerCmds {
 			cmd := exec.Command("bundle", cmds...)
 			return execute(cmd, path, cp.Verbose)
 		},
+		dir: cp.Dir,
 	}
 }
 
@@ -73,6 +77,7 @@ func NewRakeCmd(cp CmdProps) RakeCmds {
 			cmd := exec.Command("rake", cmds...)
 			return execute(cmd, path, cp.Verbose)
 		},
+		dir: cp.Dir,
 	}
 }
 

--- a/cli/pkg/shell/git.go
+++ b/cli/pkg/shell/git.go
@@ -110,8 +110,17 @@ func (c *client) CherryPick(commitOrContinue string) error {
 	if commitOrContinue == "--continue" {
 		c.cmd("add", "--all")
 	}
+
 	pick := append([]string{"cherry-pick"}, commitOrContinue)
-	return c.cmd(pick...)
+	if err := c.cmd(pick...); err != nil {
+		// let's try fetching the commit and cherry-picking again
+
+		if err := c.cmd("fetch", "origin", commitOrContinue); err != nil {
+			return err
+		}
+		return c.cmd(pick...)
+	}
+	return nil
 }
 
 func (c *client) StatConflicts() ([]string, error) {

--- a/cli/pkg/shell/git.go
+++ b/cli/pkg/shell/git.go
@@ -20,6 +20,7 @@ type GitCmds interface {
 	IsPorcelain() bool
 	PushTag(string, ...string) error
 	Log(...string) error
+	CherryPick(string) error
 }
 
 func (c *client) Clone(args ...string) error {
@@ -100,4 +101,9 @@ func (c *client) PushTag(tag string, annotate ...string) error {
 func (c *client) Log(args ...string) error {
 	log := append([]string{"log"}, args...)
 	return c.cmd(log...)
+}
+
+func (c *client) CherryPick(commit string) error {
+	pick := append([]string{"cherry-pick"}, commit)
+	return c.cmd(pick...)
 }

--- a/cli/pkg/utils/utils.go
+++ b/cli/pkg/utils/utils.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"os"
 	"os/exec"
+
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 )
 
 func SetupNode(dir string) error {
@@ -10,6 +12,7 @@ func SetupNode(dir string) error {
 
 	// Check for nvm
 	if os.Getenv("NVM_DIR") != "" {
+		console.Info("Setting up node via nvm in %s", dir)
 		cmd = exec.Command("bash", "-l", "-c", "$NVM_DIR/nvm.sh", "use")
 		cmd.Path = "/bin/bash"
 	}
@@ -20,5 +23,4 @@ func SetupNode(dir string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-
 }

--- a/cli/pkg/utils/utils.go
+++ b/cli/pkg/utils/utils.go
@@ -1,44 +1,9 @@
 package utils
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
-	"time"
 )
-
-func ValidateVersion(version string) bool {
-	re := regexp.MustCompile(`v*(\d+)\.(\d+)\.(\d+)$`)
-	return re.MatchString(version)
-}
-
-func IsScheduledRelease(version string) bool {
-	re := regexp.MustCompile(`^v*(\d+)\.(\d+)\.0$`)
-	return re.MatchString(version)
-}
-
-func NextReleaseDate() string {
-	weekday := time.Now().Weekday()
-	daysUntilThursday := 4 - weekday
-
-	nextThursday := time.Now().AddDate(0, 0, int(daysUntilThursday))
-
-	return nextThursday.Format("Monday January 2, 2006")
-}
-
-func NormalizeVersion(version string) (string, error) {
-	v := version
-	if version[0] == 'v' {
-		v = version[1:]
-	}
-
-	re := regexp.MustCompile(`\d+\.\d+\.\d+`)
-	if !re.MatchString(v) {
-		return "", fmt.Errorf("invalid version")
-	}
-	return v, nil
-}
 
 func SetupNode(dir string) error {
 	var cmd *exec.Cmd


### PR DESCRIPTION
Fixes #153 

This updates the `prepare gb` command to accept patch versions (e.g. 1.1071) and a `prs` flag to pass a comma separated list of PRs on gutenberg 

If the command recognizes a patch release it will branch of the prior release and then attempt cherry pick the merge commits from the passed in PRs.

If there is a merge commit the script will prompt to resolve the merge commit in the users default `$EDITOR`. if `EDITOR` is not set, the script will prompt for a command to open the conflicting files (e.g. `vim` or `code` )

Once the branch is prepared the script will prompt to edit the changelog since the changelog might not accurately reflect the changes in the patch.

## Testing
This is difficult to completely verify with out getting noisy on the Gutenberg repo. Also this is difficult to set up on forked repos. I suggest using the `WordPress/gutenberg` to test but just make sure to exit the script when prompted to create the pr i.e. a this prompt "**Ready to create the PR on WordPress/gutenberg? [y/n]**"

I also found it is easier to verify the scripts correctness by trying to recreate existing patch releases.

### Testing with merge conflicts

- Run `GBM_WORDPRESS_ORG=WordPress  go run main.go release prepare gb 1.103.2 --no-tag --prs=54281 ` to recreate the `1.103.2` release (use the --no-tag just in case the PR does get created)
- Follow the prompts to resolve any merge conflicts
- Follow the prompts to correctly update the CHANGELOG
- Note the commits to be included in the PR when the preview is presented
- Exit the script without creating the PR

### Testing with multiple PRs
- Run `GBM_WORDPRESS_ORG=WordPress  go run main.go release prepare gb 1.103.2 --no-tag --prs=54281,54096`
- Follow the same prompts as above but you should get two merge conflicts
- Note that both PR commits are listed in the commits in the PR list
- Exit the script without creating the PR

### Verifying the branching (also test with out merge conflicts)
- Run `GBM_WORDPRESS_ORG=WordPress  go run main.go release prepare gb 1.107.1 --prs=55613 --no-tag --keep`
- Note that the only prompt is to verify the change log (as of the time of this pr creation, the could change)
- Exit the script without creating the PR
- `cd` into the temporary directory
- Run `git reflog`
- Note that the log history starts on a grafted branch at the tag `rnmobile/1.107.0`
It should look something like :
```reflog
d6311ae (HEAD -> rnmobile/release_1.107.1) HEAD@{0}: commit: Release script: Update podfile
6451ed7 HEAD@{1}: reset: moving to HEAD
6451ed7 HEAD@{2}: commit: Release script: Update CHANGELOG for version 1.107.1
b7c4eb7 HEAD@{3}: commit: Release script: Update react-native-editor version to 1.107.1
f84d2b8 HEAD@{4}: cherry-pick: [RNMobile] Fix error when pasting deeply nested structure content (#55613)
1c3a1ac (grafted, tag: rnmobile/1.107.0) HEAD@{5}: checkout: moving from 1c3a1ac5b7add6ed335787e9770dc59b0c9d8d6b to rnmobile/release_1.107.1
1c3a1ac (grafted, tag: rnmobile/1.107.0) HEAD@{6}: clone: from github.com:WordPress/gutenberg
```

### Testing the editor prompt
- Run `EDITOR= GBM_WORDPRESS_ORG=WordPress  go run main.go release prepare gb 1.107.1 --prs=55613 --no-tag` to nil out `$EDITOR`
- Note the prompt to provide a command to open the change log
- Try using any text editor that can open files from the command line e.g. `vim`, `code` or `nano`
- Note that the correct file from the temp directory is opened in the chosen editor


### Regression
- Verify that the script works as expected for scheduled releases (this can easily be tested against a fork of gutenberg)

**Note** : There is no verification that a merge conflict was correctly resolved. I suspect most conflicts will be in the change notes so the last verification step should surface any issues with that file.

**Note**: The editor prompts have only been tested with `vim`,`code` and `nano` but in theory any command that takes a list of files should work.