### PR TITLE
CLI: Fix how nvm installs node

### DIFF
--- a/cli/pkg/utils/utils.go
+++ b/cli/pkg/utils/utils.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"regexp"
 	"time"
+
+	"github.com/wordpress-mobile/gbm-cli/pkg/console"
 )
 
 func ValidateVersion(version string) bool {
@@ -45,12 +47,16 @@ func SetupNode(dir string) error {
 
 	// Check for nvm
 	if os.Getenv("NVM_DIR") != "" {
-		cmd = exec.Command("bash", "-l", "-c", "$NVM_DIR/nvm.sh", "use")
+		cmd = exec.Command("bash", "-l", "-c", ". $NVM_DIR/nvm.sh && nvm use")
 		cmd.Path = "/bin/bash"
 	}
 
 	// @TODO check for asdf and set up the command accordingly
 
+	if cmd == nil {
+		console.Warn("No node version manager found. Using system node.")
+		return nil
+	}
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This fixes how nvm is used to load the correct node version.

I believe previous attempts to fix this were masked by setting the global node to match the required version.

## Testing
- Check to make sure the default node version does not match the one in the Gutenberg .nvmrc file (fork or main repo works)
- Run the `prepare gb {version}` command
- Notice after the "Setting up Gutenberg node environment" that nvm logs that it found a .nvmrc file and switched node versions
- Confirm that the node set up succeeds