### PR TITLE
[CLI] Don't create a temp workspace on CI

### DIFF
--- a/gbm-cli/cmd/workspace/workspace.go
+++ b/gbm-cli/cmd/workspace/workspace.go
@@ -30,6 +30,13 @@ func NewWorkspace() (Workspace, error) {
 		console.Info("GBM_NO_WORKSPACE is set, not creating a workspace directory")
 		w.disabled = true
 	}
+
+	if _, ci := os.LookupEnv("CI"); ci {
+		console.Info("CI environment detected, not creating a workspace directory")
+		w.disabled = true
+		w.dir = "."
+	}
+
 	if err := w.create(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #174 

We won't need a temp directory on a CI assuming we are spinning up a new VM on each run (like what happens on Github Workflows)

Instead we can just use the directory set up by the CI to run the commands.

This adds a check for the `CI` env before creating a temp directory. Since a temp directory is not created, nothing is deleted after the command runs

## Testing 
- Create a build to some empty directory e.g. `go build ~/some-test-directory/gbm-cli`
- `cd` into that directory and create a new empty directory `gb`
- From the directory created in the last step run `CI=true ../gbm-cli release prepare gb {version} --no-tag`
- Notice a message about not creating a temp directory
- Exit before creating the PR
- Note that Gutenberg is cloned to the current directory 
- Verify that nothing was deleted at the end of the command run
