### PR TITLE
Remove duplicate console command for `--keep` flag

### DIFF
--- a/gbm-cli/cmd/workspace/workspace.go
+++ b/gbm-cli/cmd/workspace/workspace.go
@@ -56,11 +56,6 @@ func (w *workspace) setCleaner() {
 			return
 		}
 
-		if w.keep {
-			console.Info("Keeping temporary directory %s", w.dir)
-			return
-		}
-
 		if err := os.RemoveAll(w.dir); err != nil {
 			console.Error(err)
 		}


### PR DESCRIPTION
When testing patch releases, I noted that there are duplicate `console.Info` declarations in the CLI when running the `prepare` command with the `--keep` flag:

```
[INFO] Finished preparing Gutenberg Mobile PR
[INFO] 
Finished preparing PRs:
https://github.com/derekblank/gutenberg/pull/30
https://github.com/derekblank/gutenberg-mobile/pull/9
[INFO] Keeping temporary directory /var/folders/xk/xmtl5xjx33v_bp94749wm0j00000gn/T/gbm-1558918830
[INFO] Keeping temporary directory /var/folders/xk/xmtl5xjx33v_bp94749wm0j00000gn/T/gbm-1558918830
```

This PR removes the `console.Info` in `setCleaner`. 

### Testing
1. Run `prepare all` with the `--keep` flag, e.g.: `go run main.go release prepare all 1.115.2 --keep`
2. Note only one "Keeping temporary directory [...]" line is logged to the console.