### PR TITLE
[CLI] Updates for CI workflows

### DIFF
--- a/gbm-cli/pkg/console/console.go
+++ b/gbm-cli/pkg/console/console.go
@@ -106,6 +106,10 @@ func Error(err error) {
 }
 
 func Confirm(ask string) bool {
+	// If not in a tty (CI) return true
+	if os.Getenv("CI") == "true" {
+		return true
+	}
 	var response string
 	fmt.Print(Highlight.Sprintf("%s [y/n]: ", ask))
 

--- a/gbm-cli/pkg/gh/gh.go
+++ b/gbm-cli/pkg/gh/gh.go
@@ -444,6 +444,10 @@ func labelRequest(rpo string, prNum int, labels []string) ([]Label, error) {
 }
 
 func PreviewPr(rpo, dir, branchFrom string, pr PullRequest) {
+	// if not in a tty (CI) don't print the preview
+	if os.Getenv("CI") == "true" {
+		return
+	}
 	org := repo.GetOrg(rpo)
 	row := console.Row
 

--- a/gbm-cli/pkg/release/gb.go
+++ b/gbm-cli/pkg/release/gb.go
@@ -42,7 +42,7 @@ func CreateGbPR(build Build) (gh.PullRequest, error) {
 		console.Info("Cloning Gutenberg to %s", dir)
 
 		// Let's clone into the current directory so that the git client can find the .git directory
-		err := git.Clone(repo.GetRepoPath("gutenberg"), "--branch", build.Base.Ref, "--depth=1", ".")
+		err := git.Clone(repo.GetRepoHttpsPath("gutenberg"), "--branch", build.Base.Ref, "--depth=1", ".")
 		if err != nil {
 			return pr, fmt.Errorf("error cloning the Gutenberg repository: %v", err)
 		}

--- a/gbm-cli/pkg/release/gbm.go
+++ b/gbm-cli/pkg/release/gbm.go
@@ -42,7 +42,7 @@ func CreateGbmPR(build Build) (gh.PullRequest, error) {
 		return pr, nil
 	} else {
 		console.Info("Cloning Gutenberg Mobile to %s", dir)
-		err := git.Clone(repo.GetRepoPath("gutenberg-mobile"), "--branch", build.Base.Ref, "--depth=1", "--recursive", ".")
+		err := git.Clone(repo.GetRepoHttpsPath("gutenberg-mobile"), "--branch", build.Base.Ref, "--depth=1", "--recursive", ".")
 		if err != nil {
 			return pr, fmt.Errorf("error cloning the Gutenberg Mobile repository: %v", err)
 		}

--- a/gbm-cli/pkg/release/integrate/integrate.go
+++ b/gbm-cli/pkg/release/integrate/integrate.go
@@ -111,7 +111,7 @@ func (ri *ReleaseIntegration) Run(dir string) (gh.PullRequest, error) {
 func (ri *ReleaseIntegration) cloneRepo(git shell.GitCmds) error {
 	// Check if release branch already exists
 	rpo := ri.Target.GetRepo()
-	repoPath := repo.GetRepoPath(rpo)
+	repoPath := repo.GetRepoHttpsPath(rpo)
 
 	branch := fmt.Sprintf(release.IntegrateBranchName, ri.Version)
 	exists, err := gh.SearchBranch(rpo, branch)
@@ -121,7 +121,7 @@ func (ri *ReleaseIntegration) cloneRepo(git shell.GitCmds) error {
 
 	if (exists != gh.Branch{}) {
 		console.Info("Cloning repo at release branch %s", branch)
-		if err := git.Clone("-b", branch, "--depth=1", repoPath, "."); err != nil {
+		if err := git.Clone(repoPath, "-b", branch, "--depth=1", "."); err != nil {
 			return err
 		}
 	} else {

--- a/gbm-cli/pkg/repo/repo.go
+++ b/gbm-cli/pkg/repo/repo.go
@@ -65,3 +65,8 @@ func GetRepoPath(repo string) string {
 	org := GetOrg(repo)
 	return fmt.Sprintf("git@github.com:%s/%s", org, repo)
 }
+
+func GetRepoHttpsPath(repo string) string {
+	org := GetOrg(repo)
+	return fmt.Sprintf("https://github.com/%s/%s", org, repo)
+}

--- a/gbm-cli/pkg/repo/repo.go
+++ b/gbm-cli/pkg/repo/repo.go
@@ -53,7 +53,7 @@ func GetOrg(repo string) string {
 	case WordPressAndroidRepo:
 		fallthrough
 	case ReleaseToolkitGutenbergMobileRepo:
-		fallthrough
+		return "wordpress-mobile"
 	case WordPressIosRepo:
 		return WpMobileOrg
 	default:

--- a/gbm-cli/pkg/repo/repo.go
+++ b/gbm-cli/pkg/repo/repo.go
@@ -69,9 +69,8 @@ func GetRepoPath(repo string) string {
 func GetRepoHttpsPath(repo string) string {
 	org := GetOrg(repo)
 	token := os.Getenv("GITHUB_TOKEN")
-	user := os.Getenv("GITHUB_USER")
-	if token != "" && user != "" {
-		return fmt.Sprintf("https://%s:%s@github.com/%s/%s", user, token, org, repo)
+	if token != "" {
+		return fmt.Sprintf("https://%s@github.com/%s/%s", token, org, repo)
 	}
 	return fmt.Sprintf("https://github.com/%s/%s", org, repo)
 }

--- a/gbm-cli/pkg/repo/repo.go
+++ b/gbm-cli/pkg/repo/repo.go
@@ -16,6 +16,7 @@ var (
 	WpMobileOrg   string
 	WordPressOrg  string
 	AutomatticOrg string
+	ToolkitOrg string
 )
 
 func init() {
@@ -40,6 +41,13 @@ func InitOrgs() {
 	} else {
 		AutomatticOrg = gbmAutomatticOrg
 	}
+
+	if gbmToolkitOrg, ok := os.LookupEnv("GBM_TOOLKIT_ORG"); !ok {
+		ToolkitOrg = "wordpress-mobile"
+	} else {
+		ToolkitOrg = gbmToolkitOrg
+	}
+
 }
 
 func GetOrg(repo string) string {
@@ -53,7 +61,7 @@ func GetOrg(repo string) string {
 	case WordPressAndroidRepo:
 		fallthrough
 	case ReleaseToolkitGutenbergMobileRepo:
-		return "wordpress-mobile"
+		return ToolkitOrg
 	case WordPressIosRepo:
 		return WpMobileOrg
 	default:

--- a/gbm-cli/pkg/repo/repo.go
+++ b/gbm-cli/pkg/repo/repo.go
@@ -68,5 +68,10 @@ func GetRepoPath(repo string) string {
 
 func GetRepoHttpsPath(repo string) string {
 	org := GetOrg(repo)
+	token := os.Getenv("GITHUB_TOKEN")
+	user := os.Getenv("GITHUB_USER")
+	if token != "" && user != "" {
+		return fmt.Sprintf("https://%s:%s@github.com/%s/%s", user, token, org, repo)
+	}
 	return fmt.Sprintf("https://github.com/%s/%s", org, repo)
 }


### PR DESCRIPTION
Switches the git clone command to use `https://` instead of `git@`. This will allow us to clone the repos without ssh keys. 

This is needed to run the commands on CI where we will use a Github Token to access the repos

Also includes a check to return true from `console.Confirm` and skips printing the PR Preview if running on CI 

## Testing
Confirm that any of the release command can still clone and push to the repos.