### PR TITLE
[CLI] Fixes for issues found durring the 1.108.0 release

### DIFF
--- a/gbm-cli/cmd/workspace/workspace.go
+++ b/gbm-cli/cmd/workspace/workspace.go
@@ -59,7 +59,7 @@ func (w *workspace) create() error {
 
 func (w *workspace) setCleaner() {
 	w.cleaner = func() {
-		if w.disabled || w.dir == "" {
+		if w.disabled || w.dir == "" || w.keep {
 			return
 		}
 

--- a/gbm-cli/pkg/release/integrate/ios.go
+++ b/gbm-cli/pkg/release/integrate/ios.go
@@ -34,7 +34,7 @@ func (ii IosIntegration) UpdateGutenbergConfig(dir string, gbmPr gh.PullRequest)
 		updates = []string{".ref.tag = \"v" + gbmPr.ReleaseVersion + "\"", "del(.ref.commit)"}
 	} else {
 		console.Info("Updating gutenberg-mobile ref to the commit %s", gbmPr.Head.Sha)
-		updates = []string{".ref.commit = " + gbmPr.Head.Sha + "\"", "del(.ref.tag)"}
+		updates = []string{".ref.commit = \"" + gbmPr.Head.Sha + "\"", "del(.ref.tag)"}
 	}
 
 	configPath := filepath.Join(dir, "Gutenberg/config.yml")

--- a/gbm-cli/pkg/repo/repo.go
+++ b/gbm-cli/pkg/repo/repo.go
@@ -16,7 +16,7 @@ var (
 	WpMobileOrg   string
 	WordPressOrg  string
 	AutomatticOrg string
-	ToolkitOrg string
+	ToolkitOrg    string
 )
 
 func init() {
@@ -60,10 +60,10 @@ func GetOrg(repo string) string {
 		fallthrough
 	case WordPressAndroidRepo:
 		fallthrough
-	case ReleaseToolkitGutenbergMobileRepo:
-		return ToolkitOrg
 	case WordPressIosRepo:
 		return WpMobileOrg
+	case ReleaseToolkitGutenbergMobileRepo:
+		return ToolkitOrg
 	default:
 		return ""
 	}


### PR DESCRIPTION
- The ios integration step failed when trying to update the config yaml file. There was a missing escaped quote.
-  Fixed the order of the org look up switch.
-  Fix `--keep` so it keeps the tempdir