### PR TITLE
[CLI] Add watch feature to release status

### DIFF
--- a/gbm-cli/pkg/console/console.go
+++ b/gbm-cli/pkg/console/console.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
@@ -97,6 +98,12 @@ func Warn(format string, args ...interface{}) {
 
 func Inspect(i interface{}) {
 	spew.Dump(i)
+}
+
+func Clear() {
+	cmd := exec.Command("clear")
+	cmd.Stdout = os.Stdout
+	cmd.Run()
 }
 
 func Error(err error) {


### PR DESCRIPTION
Adds a `--watch` and `--time` flag to the status command.
Makes is easier to know when the platform builds are ready

I also cleaned up some of the not so helpful warning messages

## Testing
Try the new watch flag on an existing release