### PR TITLE
Update release checklist 

### DIFF
--- a/gbm-cli/README.md
+++ b/gbm-cli/README.md
@@ -8,16 +8,18 @@ The current features include:
 - Commands to wrangle Gutenberg Mobile releases
 
 ## Installing
-Check the latest release in this repository for the binary builds. Currently we only build for MacOS arm64 (apple silicon). The script has only been tested on apple silicon but build of other platforms should work as expected. See the official [go build](https://go.dev/ref/mod#go-install) documentation for alternative builds.
+Check the [latest release](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases/latest) in this repository for the binary builds.
+Currently we only build for MacOS arm64 (apple silicon). The script has only been tested on apple silicon but builds of other platforms should work as expected. See the official [go build](https://go.dev/ref/mod#go-install) documentation for alternative builds.
 
-If using apple silicon, download the `gbm-cli` binary from the [latest release(https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases)
-Place the executable in your PATH and reload your shell. Try
+If using apple silicon, download the `gbm-cli` binary from the [latest release](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases/latest)
+Place the executable in your `$PATH` and reload your shell. Try
 
 ```
 $ gbm-cli --version
 ```
 
 To verify installation.
+
 
 If `go` (above version `1.21`) is installed you can also use:
 

--- a/gbm-cli/cmd/render/checklist.go
+++ b/gbm-cli/cmd/render/checklist.go
@@ -19,14 +19,15 @@ var releaseDate string
 var checkAztec bool
 
 type templateData struct {
-	Version      string
-	Scheduled    bool
-	Date         string
-	Message      string
-	ReleaseUrl   string
-	HostVersion  string
-	IncludeAztec bool
-	CheckAztec   bool
+	Version            string
+	Scheduled          bool
+	Date               string
+	Message            string
+	ReleaseUrl         string
+	HostVersion        string
+	IncludeAztec       bool
+	CheckAztec         bool
+	BuildkitReleaseUrl string
 }
 
 // checklistCmd represents the checklist command
@@ -66,14 +67,15 @@ var ChecklistCmd = &cobra.Command{
 			Path:  "templates/checklist/checklist.html",
 			Funcs: template.FuncMap{"RenderAztecSteps": renderAztecSteps},
 			Data: templateData{
-				Version:      version,
-				Scheduled:    scheduled,
-				ReleaseUrl:   releaseUrl,
-				Date:         releaseDate,
-				Message: 	  message,
-				HostVersion:  hostVersion,
-				IncludeAztec: includeAztec,
-				CheckAztec:   checkAztec,
+				Version:            version,
+				Scheduled:          scheduled,
+				ReleaseUrl:         releaseUrl,
+				Date:               releaseDate,
+				Message:            message,
+				HostVersion:        hostVersion,
+				IncludeAztec:       includeAztec,
+				CheckAztec:         checkAztec,
+				BuildkitReleaseUrl: "https://buildkite.com/automattic/gutenberg-mobile/builds?branch=" + semver.Vstring(),
 			},
 		}
 

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -37,11 +37,15 @@
 <h3>Create the Release{{ if .Scheduled }} (Thursday) {{end}}</h3>
 <!-- /wp:heading -->
 
-{{ Task `Install or update <code>gbm-cli</code>. See the [Installing](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile#installing) in the <code>gbm-cli</code> README. ` }}
+{{ Task `Install or update <code>gbm-cli</code>. See the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile#installing">Installing</a> in the <code>gbm-cli</code> README and compare <br />
+<code>$ gbm-cli --version</code>
+with the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases">latest release version</a>.` }}
 
-{{ Task `Run <code>gbm-cli release prepare all %s</code> to create the gutenberg and gutenberg-mobile release PRs.` .Version }}
+{{ Task `Create the Gutenberg and Gutenberg Mobile release PR by running:
+  <pre>$ gbm-cli release prepare all %s</pre>` .Version }}
 
-{{ Task `Once the CI tasks succeed, run the integrate command to create the main apps PRs for WordPress-iOS and WordPress-Android: <code>gbm-cli release integrate %s</code>` .Version }}
+{{ Task `After the CI tasks succeed, create the WordPress-iOS and WordPress-Android integration PRs by running:
+  <pre>$ gbm-cli release integrate %s</pre>` .Version }}
 
 {{ if .Scheduled }}
 <!-- wp:group -->
@@ -115,7 +119,8 @@ The 2 files are:
 
 Rename them to <code>{platform}-App.js.map</code> and add them as assets to the <a href="https://github.com/wordpress-mobile/gutenberg-mobile/releases/tag/v%s">Github release.</a>` .BuildkitReleaseUrl .Version }}
 
-{{ Task `run <code>gbm-cli release integrate %s</code> to update the integration PRs with the release tag` .Version}}
+{{ Task `Update the integration PRs with the release tag by running:
+  <pre>$ gbm-cli release integrate %s</pre>` .Version}}
 
 {{ Task `Merge the integration PRs once the CI steps pass`}}
 

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -37,9 +37,9 @@
 <h3>Create the Release{{ if .Scheduled }} (Thursday) {{end}}</h3>
 <!-- /wp:heading -->
 
-{{ Task `Pull the latest version of the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases">CLI</a>.` }}
+{{ Task `Check your version of <code>gbm-cli</code> by running <code>gbm-cli --version</code>. If you are not on the latest version, install the latest <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases">Release kit release</a>` }}
 
-{{ Task `In your clone of the <code>cli</code> directory, run the prepare command: <code>go run main.go release prepare all %s</code> to create the gutenberg and gutenberg-mobile release PRs.` }}
+{{ Task `Run <code>gbm-cli release prepare all %s</code> to create the gutenberg and gutenberg-mobile release PRs.` }}
 
 {{ Task `Once the CI tasks succeed, run the integrate command to create the main apps PRs for WordPress-iOS and WordPress-Android: <code>go run main.go release integrate %s</code> `}}
 

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -104,24 +104,11 @@ and don't forget to run <code>npm run bundle</code> in gutenberg-mobile again if
 
 {{ Task `<a href="%s">Create a new gutenberg-mobile GitHub Release</a>. Include a list of changes in the release description. Ensure the checkmark "Set as the latest release" is checked, and <strong>publish the release with the "Publish release" button.</strong>` .ReleaseUrl }}
 
-{{ Task `Wait until all CI jobs for the published tag finish and succeed.` }}
+{{ Task `Wait until all <a href="%s">CI jobs for the published tag</a> to finish and succeed.` .BuildkitReleaseUrl}}
 
-{{ Task `Navigate to the Buildkite job that built the JS bundles (<code>Build JS Bundles</code>) for the published tag. Open the job and navigate to the "Artifacts" tab. Locate the composed source maps (they have file name <code>bundle/{platform}/App.composed.js.map</code>) and download them.` }}
-
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
-{{ Task `Navigate and edit the GitHub release. Attach the composed source maps to the release (you can drag and drop the files in the “Attach binaries” drop area). Once they are uploaded, update the artifact’s name following this format:` }}
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
-<li>File: <code>bundle/android/App.composed.js.map</code> – Artifact name: <code>android-App.js.map</code></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li>File: <code>bundle/ios/App.composed.js.map</code> – Artifact name: <code>ios-App.js.map</code></li>
-<!-- /wp:list-item --></ul>
-
-<!-- /wp:list --></div>
-<!-- /wp:group -->
+{{ Task `Download the composed source maps from the <a href="%s"></a>release build in Buildkite</a>.
+The 2 files are: <code>Build JS Bundles (step) > Artifacts (tab) > bundle/{platform}/App.composed.js.map </code>.
+Rename them to {platform}-App.js.map and add them as assets to the Github release` .BuildkitReleaseUrl }}
 
 {{ Task `In WPiOS, update the reference to point to the <em>tag</em> of the Release created in the previous task.` }}
 

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -39,9 +39,9 @@
 
 {{ Task `Check your version of <code>gbm-cli</code> by running <code>gbm-cli --version</code>. If you are not on the latest version, install the latest <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases">Release kit release</a>` }}
 
-{{ Task `Run <code>gbm-cli release prepare all %s</code> to create the gutenberg and gutenberg-mobile release PRs.` }}
+{{ Task `Run <code>gbm-cli release prepare all %s</code> to create the gutenberg and gutenberg-mobile release PRs.` .Version }}
 
-{{ Task `Once the CI tasks succeed, run the integrate command to create the main apps PRs for WordPress-iOS and WordPress-Android: <code>go run main.go release integrate %s</code> `}}
+{{ Task `Once the CI tasks succeed, run the integrate command to create the main apps PRs for WordPress-iOS and WordPress-Android: <code>gbm-cli release integrate %s</code>` .Version }}
 
 {{ if .Scheduled }}
 <!-- wp:group -->

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -106,9 +106,14 @@ and don't forget to run <code>npm run bundle</code> in gutenberg-mobile again if
 
 {{ Task `Wait until all <a href="%s">CI jobs for the published tag</a> to finish and succeed.` .BuildkitReleaseUrl}}
 
-{{ Task `Download the composed source maps from the <a href="%s"></a>release build in Buildkite</a>.
-The 2 files are: <code>Build JS Bundles (step) > Artifacts (tab) > bundle/{platform}/App.composed.js.map </code>.
-Rename them to {platform}-App.js.map and add them as assets to the Github release` .BuildkitReleaseUrl }}
+{{ Task `Download the composed source maps from the <a href="%s">release build in Buildkite</a>.<br />
+The 2 files are:
+
+<pre>
+  Build JS Bundles (step) > Artifacts (tab) > bundle/{platform}/App.composed.js.map
+</pre>
+
+Rename them to <code>{platform}-App.js.map</code> and add them as assets to the <a href="https://github.com/wordpress-mobile/gutenberg-mobile/releases/tag/v%s">Github release.</a>` .BuildkitReleaseUrl .Version }}
 
 {{ Task `run <code>gbm-cli release integrate %s</code> to update the integration PRs with the release tag` .Version}}
 

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -136,6 +136,8 @@ Rename them to {platform}-App.js.map and add them as assets to the Github releas
 
 {{ Task `Close the <a href="https://github.com/wordpress-mobile/gutenberg-mobile/milestones">Gutenberg Mobile milestone</a> that corresponds to this release.` }}
 
+{{ Task `Create a <a href="https://github.com/wordpress-mobile/gutenberg-mobile/milestones/new"> new Gutenberg Mobile milestone</a> for the next release` }}
+
 <!-- wp:heading {"level":3} -->
 <h3>Merge Release Branches</h3>
 <!-- /wp:heading -->

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -37,7 +37,7 @@
 <h3>Create the Release{{ if .Scheduled }} (Thursday) {{end}}</h3>
 <!-- /wp:heading -->
 
-{{ Task `Check your version of <code>gbm-cli</code> by running <code>gbm-cli --version</code>. If you are not on the latest version, install the latest <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/releases">Release kit release</a>` }}
+{{ Task `Install or update <code>gbm-cli</code>. See the [Installing](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile#installing) in the <code>gbm-cli</code> README. ` }}
 
 {{ Task `Run <code>gbm-cli release prepare all %s</code> to create the gutenberg and gutenberg-mobile release PRs.` .Version }}
 

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -110,11 +110,9 @@ and don't forget to run <code>npm run bundle</code> in gutenberg-mobile again if
 The 2 files are: <code>Build JS Bundles (step) > Artifacts (tab) > bundle/{platform}/App.composed.js.map </code>.
 Rename them to {platform}-App.js.map and add them as assets to the Github release` .BuildkitReleaseUrl }}
 
-{{ Task `In WPiOS, update the reference to point to the <em>tag</em> of the Release created in the previous task.` }}
+{{ Task `run <code>gbm-cli release integrate %s</code> to update the integration PRs with the release tag` .Version}}
 
-{{ Task `In WPAndroid, update the <code>gutenbergMobileVersion</code> in <code>build.gradle</code> to point to the <em>tag</em> of the Release used in the previous task.` }}
-
-{{ Task `Main apps PRs should be ready to merge to their <code>trunk</code> branches now. Merge them or get them merged.`}}
+{{ Task `Merge the integration PRs once the CI steps pass`}}
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">


### PR DESCRIPTION
### Changes

- Instruct to install the latest `gbm-cli` release instead of cloning the toolkit repo
<img width="770" alt="Screenshot 2023-11-10 at 2 27 45 PM" src="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/assets/744755/143db663-7444-49d7-b9b3-6a7cfd8b5dd5">

- Switch out mentions of `go run main.go` with `gbm-cli`
<img width="766" alt="Screenshot 2023-11-10 at 2 27 56 PM" src="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/assets/744755/c0f1eabf-18b7-4764-891d-7b78d83f81bc">

- Add a task to create a new Milestone
<img width="767" alt="Screenshot 2023-11-10 at 2 28 21 PM" src="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/assets/744755/fc3777cc-a3e1-44fb-9fd7-23c8087686c2">

- Instruct the use of `gbm-cli` to update the integration PRs once the GBM release is published.
<img width="775" alt="Screenshot 2023-11-10 at 2 28 09 PM" src="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/assets/744755/4f1d1609-41df-4441-983b-8d11e0fb954a">


- Simplify the adding release assets tasks into one task with direct links to the build:
<img width="832" alt="Screenshot 2023-11-10 at 2 26 55 PM" src="https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/assets/744755/c1ce9d93-d8b0-4e84-b948-84972b59577a">

- Fix a few typos