### PR TITLE
[CLI] Version bump

### DIFF
--- a/gbm-cli/cmd/root.go
+++ b/gbm-cli/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli/pkg/gh"
 )
 
-const Version = "v1.2.0"
+const Version = "v1.3.0"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
This bumps the version to 1.2.1

Changes :
- https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/221
- https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/222
- https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/223
- https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/224
