### PR TITLE
[CLI] Fix Github Token handling

### DIFF
--- a/gbm-cli/cmd/root.go
+++ b/gbm-cli/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli/pkg/gh"
 )
 
-const Version = "v1.3.0"
+const Version = "v1.4.0"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/gbm-cli/go.mod
+++ b/gbm-cli/go.mod
@@ -5,6 +5,7 @@ go 1.21
 toolchain go1.21.2
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.15.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mikefarah/yq/v4 v4.35.2
@@ -18,7 +19,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cli/safeexec v1.0.1 // indirect
 	github.com/cli/shurcooL-graphql v0.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/elliotchance/orderedmap v1.5.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/gbm-cli/pkg/repo/repo.go
+++ b/gbm-cli/pkg/repo/repo.go
@@ -3,6 +3,8 @@ package repo
 import (
 	"fmt"
 	"os"
+
+	"github.com/cli/go-gh/v2/pkg/auth"
 )
 
 const WordPressAndroidRepo = "WordPress-Android"
@@ -76,7 +78,7 @@ func GetRepoPath(repo string) string {
 
 func GetRepoHttpsPath(repo string) string {
 	org := GetOrg(repo)
-	token := os.Getenv("GITHUB_TOKEN")
+	token, _ := auth.TokenForHost("github.com")
 	if token != "" {
 		return fmt.Sprintf("https://%s@github.com/%s/%s", token, org, repo)
 	}


### PR DESCRIPTION
This uses the same function `go-gh` uses to find the users Github auth token when cloning repos. 
Previously it was only looking for `GITHUB_TOKEN`.
This change will allow users to just run `gh auth login` to use the tool or it will work by supplying a github token via `GH_TOKEN` or `GITHUB_TOKEN` if `gh` is not installed

##Testing

### With out `gh`
1. Uninstall `gh` ( `brew uninstall gh`)
2. Make sure `gh` has not added anything to `~/.gitconfig` look for something like
```
[credential "https://github.com"]
    helper = !/opt/homebrew/bin/gh auth git-credential
```
4. Make sure `~/.config/gh/hosts.yml` does not have an `oauth_token` 
3. Try creating a test release `go run main.go release prepare gb <version> --no-tag`
4. Note that the command fails
5. Try using a [github PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) by adding that as an env : 
```
GH_TOKEN=<your github token> go run main.go release prepare gb <version> --no-tag
// or
GITHUB_TOKEN=<your gitub token> go run main.go release prepare gb <version> --no-tag
```
6. Verify that the changes can be pushed to github and that the PR is created

### With `gh` installed
1. re-install `gh` 
2. Try without logging in by repeating steps 5 and 6 above
3. Login in via `gh auth login` and **make sure to not run** `gh auth setup-git` 
4. Verify that `gh` has not modified `~./gitconfig`
5.  Try creating a test release without the exported token:  `go run main.go release prepare gb <version> --no-tag`
6. Verify that the changes can be pushed and that the PR is created

