### PR TITLE
Update checklist and include link to new basic test suite

### DIFF
--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -182,9 +182,7 @@ Merge the <code>gutenberg/after_%s</code> PR(s) only <em>AFTER</em> the main app
 
 {{ Task `Test the new changes that are included in the release PR.` }}
 
-{{ Task `Complete the <a href="https://github.com/wordpress-mobile/test-cases/tree/master/test-cases/gutenberg/writing-flow">general writing flow test cases</a>.` }}
-
-{{ Task `Complete the <a href="https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/unsupported-block-editing.md#unsupported-block-editing---test-cases">Unsupported Block Editor test cases</a>.` }}
+{{ Task `Complete the <a href="https://github.com/wordpress-mobile/test-cases/tree/master/test-suites/gutenberg/basic-test-suite.md">basic test suite</a>.` }}
 
 {{ Task `Complete the <a href="https://docs.google.com/spreadsheets/d/1uJ_o1t5fxeCRfGWTTImmieNgXf_sLflB1iOnKLyhPAw/edit#gid=0">functionality tests scheduled for Android</a>` }}
 


### PR DESCRIPTION
After the new suite was added in https://github.com/wordpress-mobile/test-cases/pull/161, we can remove the references to the writing flow and unsupported block editor, as they are now grouped in the basic test suite.