### PR TITLE
[CLI] Bump version to 1.5.0

### DIFF
--- a/gbm-cli/cmd/root.go
+++ b/gbm-cli/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli/pkg/gh"
 )
 
-const Version = "v1.4.0"
+const Version = "v1.5.0"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Changes included in this version:
* https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/235