### PR TITLE
[CLI]Update Integrate patch release

### DIFF
--- a/gbm-cli/cmd/release/README.md
+++ b/gbm-cli/cmd/release/README.md
@@ -50,6 +50,7 @@ go run main.go release integrate v1.107.0
 **Flags**
 - `-a`, `--android`: Only integrate Android
 - `-i`, `--ios`: Only integrate iOS
+- `-V` : Host app version (required for patch releases)
 - `-h`, `--help`: Command line help for `integrate` command
 
 ### status
@@ -59,5 +60,5 @@ Command used to check the status of any given release:
 **Usage**
 
 ```
-go run main.go release status 1.07.0 
+go run main.go release status 1.07.0
 ```

--- a/gbm-cli/cmd/release/integrate.go
+++ b/gbm-cli/cmd/release/integrate.go
@@ -16,6 +16,7 @@ import (
 )
 
 var android, ios, both bool
+var hostVersion string
 
 var IntegrateCmd = &cobra.Command{
 	Use:   "integrate",
@@ -37,6 +38,13 @@ var IntegrateCmd = &cobra.Command{
 			BaseBranch: "trunk",
 			HeadBranch: fmt.Sprintf("gutenberg/integrate_release_%s", version),
 			GbmPr:      gbmPr,
+		}
+
+		if semver.IsPatchRelease() {
+			if hostVersion == "" {
+				exitIfError(errors.New("host version is required for patch releases"), 1)
+			}
+			ri.BaseBranch = fmt.Sprintf("release/%s", hostVersion)
 		}
 
 		results := []gh.PullRequest{}
@@ -113,4 +121,5 @@ func init() {
 	tempDir = workspace.Dir()
 	IntegrateCmd.Flags().BoolVarP(&android, "android", "a", false, "Only integrate Android")
 	IntegrateCmd.Flags().BoolVarP(&ios, "ios", "i", false, "Only integrate iOS")
+	IntegrateCmd.Flags().StringVarP(&hostVersion, "host-version", "V", "", "host app version")
 }

--- a/gbm-cli/templates/checklist/checklist.html
+++ b/gbm-cli/templates/checklist/checklist.html
@@ -44,8 +44,13 @@ with the <a href="https://github.com/wordpress-mobile/release-toolkit-gutenberg-
 {{ Task `Create the Gutenberg and Gutenberg Mobile release PR by running:
   <pre>$ gbm-cli release prepare all %s</pre>` .Version }}
 
+{{ if .Scheduled}}
 {{ Task `After the CI tasks succeed, create the WordPress-iOS and WordPress-Android integration PRs by running:
   <pre>$ gbm-cli release integrate %s</pre>` .Version }}
+{{ else }}
+{{ Task `After the CI tasks succeed, create the WordPress-iOS and WordPress-Android integration PRs by running:
+  <pre>$ gbm-cli release integrate %s -V </pre>` .Version .HostVersion}}
+{{ end }}
 
 {{ if .Scheduled }}
 <!-- wp:group -->


### PR DESCRIPTION
This adds the ability to integrate patch release into the main apps.

It adds a host version flag (`-V`) to the `release integrate` command.

It will also fail if the trying to integrate a patch where the host version is not supplied.

NOTE: This will work for beta fixes but might not work for hot fixes where the release branch no longer exists. Issue to handle hotfixes https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/issues/239

## Testing
Follow the [Testing](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/trunk/gbm-cli/Testing.md) guide to set up the tool to use forked repos.

Note: A patch PR is required on the forked Gutenberg Mobile repo before attempting the patch integration. This can be manually created to avoid requiring a Gutenberg patch PR

- Create a release branch on the forked host apps e.g. release/1.0
- Create a patch release PR on the Gutenberg Mobile fork 
- Run the integration command with the GBM patch version
- Notice the failure message requiring a host version for an patch integration
- Run the integration command again but now include the host version e.g. `-V 1.0`
- The script should open a PR against the release branch
