### PR TITLE
[CLI] Fix prepare all command

### DIFF
--- a/gbm-cli/cmd/release/prepare/all.go
+++ b/gbm-cli/cmd/release/prepare/all.go
@@ -39,6 +39,7 @@ var allCmd = &cobra.Command{
 			Base: gh.Repo{
 				Ref: "trunk",
 			},
+			Repo: "gutenberg",
 		}
 
 		isPatch := version.IsPatchRelease()
@@ -61,6 +62,7 @@ var allCmd = &cobra.Command{
 			Base: gh.Repo{
 				Ref: "trunk",
 			},
+			Repo: "gutenberg-mobile",
 		}
 
 		if isPatch {


### PR DESCRIPTION
This fixes the `prepare all` command by setting the `repo` in the build config 

## Testing
Follow the [Testing](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/trunk/gbm-cli/Testing.md) guide to set up the tool to use forked repos.

- Try `go run main.go release prepare all {version}`
- Verify that both Gutenberg and Gutenberg Mobile repos are cloned as expected.