### PR TITLE
[CLI] Prompt to add the release tag

### DIFF
--- a/gbm-cli/cmd/release/prepare/all.go
+++ b/gbm-cli/cmd/release/prepare/all.go
@@ -33,9 +33,9 @@ var allCmd = &cobra.Command{
 
 		console.Info("Preparing Gutenberg for release %s", version)
 		build := release.Build{
-			Dir:     gbDir,
-			Version: version,
-			UseTag:  !noTag,
+			Dir:         gbDir,
+			Version:     version,
+			PromptToTag: !noTag,
 			Base: gh.Repo{
 				Ref: "trunk",
 			},

--- a/gbm-cli/cmd/release/prepare/gb.go
+++ b/gbm-cli/cmd/release/prepare/gb.go
@@ -16,10 +16,10 @@ var gbCmd = &cobra.Command{
 
 		defer workspace.Cleanup()
 		build := release.Build{
-			Dir:     tempDir,
-			Version: version,
-			UseTag:  !noTag,
-			Repo:    "gutenberg",
+			Dir:         tempDir,
+			Version:     version,
+			PromptToTag: !noTag,
+			Repo:        "gutenberg",
 			Base: gh.Repo{
 				Ref: "trunk",
 			},

--- a/gbm-cli/cmd/release/prepare/root.go
+++ b/gbm-cli/cmd/release/prepare/root.go
@@ -64,7 +64,7 @@ func init() {
 	PrepareCmd.AddCommand(gbCmd)
 	PrepareCmd.AddCommand(allCmd)
 	PrepareCmd.PersistentFlags().BoolVar(&keepTempDir, "keep", false, "Keep temporary directory after running command")
-	PrepareCmd.PersistentFlags().BoolVar(&noTag, "no-tag", false, "Prevent tagging the release")
+	PrepareCmd.PersistentFlags().BoolVar(&noTag, "no-tag", false, "Prevent tagging the release. If not set, you will be prompted to tag the release")
 	PrepareCmd.PersistentFlags().StringSliceVar(&prs, "prs", []string{}, "prs to include in the release. Only used with patch releases")
 }
 

--- a/gbm-cli/pkg/release/gb.go
+++ b/gbm-cli/pkg/release/gb.go
@@ -202,10 +202,12 @@ func CreateGbPR(build Build) (gh.PullRequest, error) {
 
 	gh.PreviewPr("gutenberg", dir, build.Base.Ref, pr)
 
-	prompt := fmt.Sprintf("\nReady to create the PR on %s/gutenberg?", org)
-	cont := console.Confirm(prompt)
+	var prompt string
 
-	if !cont {
+	prompt = fmt.Sprintf("\nReady to create the PR on %s/gutenberg?", org)
+	shouldCreatePr := console.Confirm(prompt)
+
+	if !shouldCreatePr {
 		return pr, fmt.Errorf("exiting before creating PR")
 	}
 
@@ -221,7 +223,17 @@ func CreateGbPR(build Build) (gh.PullRequest, error) {
 		return pr, fmt.Errorf("pr was not created successfully")
 	}
 
-	if build.UseTag {
+	// Only tag if we are prompting to tag
+	var shouldTag bool
+
+	if build.PromptToTag {
+		prompt = fmt.Sprintf("\nDo you want to create the release tag on %s/gutenberg?", org)
+		shouldTag = console.Confirm(prompt)
+	} else {
+		shouldTag = false
+	}
+
+	if shouldTag {
 		console.Info("Adding release tag")
 		if err := git.PushTag("rnmobile/" + version); err != nil {
 			console.Warn("Error tagging the release: %v", err)

--- a/gbm-cli/pkg/release/main.go
+++ b/gbm-cli/pkg/release/main.go
@@ -6,13 +6,13 @@ import (
 )
 
 type Build struct {
-	Version semver.SemVer
-	Dir     string
-	UseTag  bool
-	Repo    string
-	Prs     []gh.PullRequest
-	Base    gh.Repo
-	Depth   string
+	Version     semver.SemVer
+	Dir         string
+	PromptToTag bool
+	Repo        string
+	Prs         []gh.PullRequest
+	Base        gh.Repo
+	Depth       string
 }
 
 type ReleaseChanges struct {


### PR DESCRIPTION
This adds a prompt before creating the release tag on Gutenberg.

The `--no-tag` flag still works as before but now without that flag the script will prompt to tag Gutenberg after it pushes up the release branch

### Testing

Follow the [Testing](https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/blob/trunk/gbm-cli/Testing.md) guide to set up the tool to use forked repos.

- Run `go run main.go release prepare gb {version} --no-tag` and confirm that the `rnmobile/{version}` tag is **not** created on the forked repo
- Run `go run main.go release prepare gb {version}` and cancel the prompt to tag the release. Confirm that the tag is **not** created on the forked repo
- Run `go run main.go release prepare gb {version}`  and confirm creating the release tag. Confirm that the tag is created on the forked repo

