### PR TITLE
[CLI] Bump version to v1.6.0

### DIFF
--- a/gbm-cli/cmd/root.go
+++ b/gbm-cli/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/gbm-cli/pkg/console"
 )
 
-const Version = "v1.5.0"
+const Version = "v1.6.0"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Includes:

- https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/237
- https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/241
- https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/242
- https://github.com/wordpress-mobile/release-toolkit-gutenberg-mobile/pull/247